### PR TITLE
Fix/set ids for lists

### DIFF
--- a/shared/components/Table/Table.js
+++ b/shared/components/Table/Table.js
@@ -19,7 +19,7 @@ const Table = ({ titles, rows, rowRender }) => (
       {
         rows.map((row, rowIndex) => {
           if (typeof rowRender === 'function') {
-            return rowRender(row, rowIndex)
+            return rowRender(row, row.id || rowIndex)
           }
         })
       }


### PR DESCRIPTION
Для строки в таблице формируется React key в виде id элемента, иначе берется index (актуально для статики). В Orders ключи исправлены.