### PR TITLE
не показывать table is empty пока идет загрузка

### DIFF
--- a/shared/components/Footer/Footer.js
+++ b/shared/components/Footer/Footer.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react'
+import { connect } from 'redaction'
 
+import actions from 'redux/actions'
 import SwapApp from 'swap.app'
 import config from 'app-config'
 
@@ -9,47 +11,36 @@ import styles from './Footer.scss'
 import Info from './Info/Info'
 import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
 
-
+@connect({
+  ipfs: 'ipfs',
+})
 @CSSModules(styles)
 export default class Footer extends Component {
-
-  state = {
-    userOnline: 0,
-    connected: false,
-    server: config.ipfs.server,
-  }
-
   componentWillMount() {
     setTimeout(() => {
-      const connected = SwapApp.services.room.connection._ipfs.isOnline()
-
-      SwapApp.services.room.connection.on('peer joined', this.userJoin)
-      this.setState({
-        connected,
-      })
+      const isOnline = SwapApp.services.room.connection._ipfs.isOnline()
+      SwapApp.services.room.connection.on('peer joined', actions.ipfs.userJoined)
+      setTimeout(() => {
+        actions.ipfs.set({
+          isOnline,
+          server: config.ipfs.server
+        })
+      }, 1000)
     }, 8000)
   }
 
   componentWillUnmount() {
-    SwapApp.services.room.connection.off('peer joined', this.userLeft)
-  }
-
-  userJoin = () => {
-    this.setState(userOnline => userOnline--)
-  }
-
-  userLeft = () => {
-    this.setState(userOnline => userOnline++)
+    SwapApp.services.room.connection.off('peer joined', actions.ipfs.userLeft)
   }
 
   render() {
-    const { userOnline, connected, server } = this.state
+    const { ipfs: { onlineUsers, isOnline, server } } = this.props
 
     return (
       <div styleName="footer">
         <WidthContainer styleName="container">
           <a href="https://t.me/swaponline" target="_blank">Need help? Join Telegram chat @swaponline</a>
-          <Info serverAddress={server} userOnline={userOnline} connected={connected} />
+          <Info serverAddress={server} onlineUsers={onlineUsers} isOnline={isOnline} />
         </WidthContainer>
       </div>
     )

--- a/shared/components/Footer/Info/Info.js
+++ b/shared/components/Footer/Info/Info.js
@@ -4,12 +4,12 @@ import cssModules from 'react-css-modules'
 import styles from './Info.scss'
 
 
-const Info = ({ userOnline, connected, serverAddress }) => (
+const Info = ({ onlineUsers, isOnline, serverAddress }) => (
   <div styleName="title">
-    <span styleName={connected ? 'connect' : 'disconnect'}>
-      {connected ? 'Connected ' : 'Loading or not available '}
+    <span styleName={isOnline ? 'connect' : 'disconnect'}>
+      {isOnline ? 'Connected ' : 'Loading or not available '}
     </span>
-    to IPFS signal {serverAddress} / peers online: {userOnline}
+    to IPFS signal {serverAddress} / peers online: {onlineUsers}
   </div>
 )
 

--- a/shared/components/Table/Table.js
+++ b/shared/components/Table/Table.js
@@ -16,11 +16,25 @@ const Table = ({ titles, rows, rowRender, textIfEmpty, isLoading, loadingText })
       </tr>
     </thead>
     <tbody>
-      { isLoading && <tr><td styleName="color">{loadingText}</td></tr> }
-      { !isLoading && !rows.length && <tr><td styleName="color">{textIfEmpty}</td></tr> }
-      { !isLoading && !!rows.length && rows.map((row, rowIndex) => {
-        return typeof rowRender === 'function' && rowRender(row, rowIndex)
-      }) }
+      {
+        isLoading && (
+          <tr>
+            <td styleName="color">{loadingText}</td>
+          </tr>
+        )
+      }
+      {
+        !isLoading && !rows.length && (
+          <tr>
+            <td styleName="color">{textIfEmpty}</td>
+          </tr>
+        )
+      }
+      {
+        !isLoading && !!rows.length && rows.map((row, rowIndex) => (
+          typeof rowRender === 'function' && rowRender(row, rowIndex)
+        ))
+      }
     </tbody>
   </table>
 )

--- a/shared/components/Table/Table.js
+++ b/shared/components/Table/Table.js
@@ -4,7 +4,7 @@ import cssModules from 'react-css-modules'
 import styles from './Table.scss'
 
 
-const Table = ({ titles, rows, rowRender, textIfEmpty }) => (
+const Table = ({ titles, rows, rowRender, textIfEmpty, isLoading, loadingText }) => (
   <table styleName="table">
     <thead>
       <tr>
@@ -16,19 +16,11 @@ const Table = ({ titles, rows, rowRender, textIfEmpty }) => (
       </tr>
     </thead>
     <tbody>
-      {
-        rows.length > 0 ? (
-          rows.map((row, rowIndex) => {
-            if (typeof rowRender === 'function') {
-              return rowRender(row, rowIndex)
-            }
-          })
-        ) : (
-          <tr>
-            <td styleName="color">{textIfEmpty}</td>
-          </tr>
-        )
-      }
+      { isLoading && <tr><td styleName="color">{loadingText}</td></tr> }
+      { !isLoading && !rows.length && <tr><td styleName="color">{textIfEmpty}</td></tr> }
+      { !isLoading && !!rows.length && rows.map((row, rowIndex) => {
+        return typeof rowRender === 'function' && rowRender(row, rowIndex)
+      }) }
     </tbody>
   </table>
 )
@@ -36,6 +28,7 @@ const Table = ({ titles, rows, rowRender, textIfEmpty }) => (
 
 Table.defaultProps = {
   textIfEmpty: 'The table is empty',
+  loadingText: 'Loading...'
 }
 
 export default cssModules(Table, styles)

--- a/shared/pages/Home/Orders/Orders.js
+++ b/shared/pages/Home/Orders/Orders.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react'
+import { connect } from 'redaction'
 import SwapApp from 'swap.app'
 import actions from 'redux/actions'
 
@@ -7,7 +8,9 @@ import Table from 'components/Table/Table'
 import MyOrders from './MyOrders/MyOrders'
 import SearchSwap from 'components/SearchSwap/SearchSwap'
 
-
+@connect({
+  ipfs: 'ipfs',
+})
 export default class Orders extends Component {
 
   state = {
@@ -56,6 +59,7 @@ export default class Orders extends Component {
     const { filter, sellCurrency, buyCurrency, handleSellCurrencySelect, handleBuyCurrencySelect, flipCurrency } = this.props
     const titles = [ 'EXCHANGE', 'YOU BUY', 'YOU SELL', 'EXCHANGE RATE', 'ACTIONS' ]
     const { orders } = this.state
+    const { ipfs: { isOnline }} = this.props
 
     const mePeer = SwapApp.services.room.peer
     const filteredOrders = this.filterOrders(orders, filter)
@@ -85,6 +89,7 @@ export default class Orders extends Component {
               update={this.updateOrders}
             />
           )}
+          isLoading={!isOnline}
         />
       </Fragment>
     )

--- a/shared/redux/actions/index.js
+++ b/shared/redux/actions/index.js
@@ -16,6 +16,7 @@ import nimiq from './nimiq'
 import referral from './referral'
 import analytics from './analytics'
 
+import ipfs from './ipfs'
 
 export default {
   filter,
@@ -31,4 +32,5 @@ export default {
   feed,
   analytics,
   referral,
+  ipfs,
 }

--- a/shared/redux/actions/ipfs.js
+++ b/shared/redux/actions/ipfs.js
@@ -1,0 +1,19 @@
+import reducers from 'redux/core/reducers'
+
+const set = payload => {
+  reducers.ipfs.set(payload)
+}
+
+const userJoined = () => {
+  reducers.ipfs.userJoined()
+}
+
+const userLeft = () => {
+  reducers.ipfs.userLeft()
+}
+
+export default {
+  set,
+  userJoined,
+  userLeft
+}

--- a/shared/redux/reduсers/index.js
+++ b/shared/redux/reduсers/index.js
@@ -4,6 +4,7 @@ import * as history from './history'
 import * as loader from './loader'
 import * as user from './user'
 import * as feeds from './feeds'
+import * as ipfs from './ipfs'
 
 
 export default {
@@ -13,4 +14,5 @@ export default {
   loader,
   user,
   feeds,
+  ipfs,
 }

--- a/shared/redux/reduсers/ipfs.js
+++ b/shared/redux/reduсers/ipfs.js
@@ -1,0 +1,26 @@
+export const initialState = {
+  isOnline: false,
+  onlineUsers: 0,
+  server: null
+}
+
+export const set = (state, payload) => ({
+  ...state,
+  ...payload
+})
+
+/**
+ * Событие "Пользователь вошел в сеть".
+ */
+export const userJoined = state => ({
+  ...state,
+  onlineUsers: state.onlineUsers + 1
+})
+
+/**
+ * Событие "Пользователь вышел из сети".
+ */
+export const userLeft = state => ({
+  ...state,
+  onlineUsers: state.onlineUsers - 1
+})


### PR DESCRIPTION
Фикс для #164 

* Был создан отдельный редюсер и экшн для `ipfs` вместо использования `state` от `Footer` (логика соединения осталась в футере как было, с одной стороны не мешает, с другой стороны, может вынести его в другое место)
* Добавлен флаг `isLoading` для `Table`, чтобы показывать плашку загрузки. Пока используется только в `Orders` (добавлена задержка в 1 секунду, потому что пользователь соединяется чуть раньше, чем приходят ордера)
* Небольшой рефакторинг в компоненте `Info`, чтобы имена свойств соответствовали редюсеру