### PR TITLE
Moment locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "human-standard-token-abi": "^1.0.2",
     "lodash": "^4.17.5",
     "moment": "^2.22.1",
+    "moment-with-locales-es6": "^1.0.1",
     "node-gyp": "^3.7.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",

--- a/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
+++ b/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'redaction'
-import moment from 'moment'
+import moment from 'moment-with-locales-es6'
 import actions from 'redux/actions'
 import Link from 'sw-valuelink'
 import { localStorage, constants } from 'helpers'
@@ -81,7 +81,7 @@ Private key: ${btcData.privateKey}\r\n
 4. paste private key and click "Ok"\r\n
 \r\n
 \r\n
-* We don\`t store your private keys and will not be able to restore them!  
+* We don\`t store your private keys and will not be able to restore them!
     `
 
     return text

--- a/shared/containers/App/App.js
+++ b/shared/containers/App/App.js
@@ -3,7 +3,7 @@ import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
 import actions from 'redux/actions'
 import { connect } from 'redaction'
-import moment from 'moment'
+import moment from 'moment-with-locales-es6'
 import { constants } from 'helpers'
 
 import CSSModules from 'react-css-modules'
@@ -20,8 +20,8 @@ import ModalConductor from 'components/modal/ModalConductor/ModalConductor'
 import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
 import NotificationConductor from 'components/notification/NotificationConductor/NotificationConductor'
 
-
-moment.locale('en-gb')
+const userLanguage = (navigator.userLanguage || navigator.language || 'en-gb').split('-')[0]
+moment.locale(userLanguage)
 
 @withRouter
 @connect({

--- a/shared/pages/History/Row/Row.js
+++ b/shared/pages/History/Row/Row.js
@@ -1,13 +1,12 @@
 import React from 'react'
 import cx from 'classnames'
-import moment from 'moment'
+import moment from 'moment-with-locales-es6'
 
 import cssModules from 'react-css-modules'
 import styles from './Row.scss'
 
 import Coin from 'components/Coin/Coin'
 import LinkTransaction from '../LinkTransaction/LinkTransaction'
-
 
 const Row = ({ type, date, direction, hash, value, confirmations }) => {
   const statusStyleName = cx('status', {
@@ -22,7 +21,7 @@ const Row = ({ type, date, direction, hash, value, confirmations }) => {
       </td>
       <td>
         <div styleName={statusStyleName}>{direction === 'in' ? 'Received ' : 'Sent '}</div>
-        <div styleName="date">{moment(date).format('MM/DD/YYYY hh:mm A')}</div>
+        <div styleName="date">{moment(date).format('LLLL')}</div>
         <LinkTransaction type={type} styleName="address" hash={hash} >{hash}</LinkTransaction>
       </td>
       <td>


### PR DESCRIPTION
Фикс для #137 

* Сейчас вместо `moment` загружается `moment-with-locales-es6` для загрузки всех языков. Лучше всего ограничить локали каким-либо списком и вернуться к использованию `moment`
* Алгоритм смотрит настройку браузера, поэтому для русского пользователя с английским интерфейсом системы будет английская нотация. Возможно, имеет смысл вынести это в настройки в будущем.
* Формат `MM/DD/YYYY hh:mm A` изменен на `LLLL`