### PR TITLE
Исправил определение корня репозитория

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,7 +1,7 @@
 import path from 'path'
 
 
-const rootPath = path.resolve(process.cwd(), '../')
+const rootPath = path.resolve(process.cwd())
 const basePath = path.resolve(__dirname, '../')
 
 const config = {


### PR DESCRIPTION
Корень репозитория определялся неверно, из-за этого webpack не мог найти swap.core, запуск и сборка падали с ошибкой.
```
...
ERROR in ./shared/instances/newSwap.js
Module not found: Error: Can't resolve 'swap.swaps' in 'R:\swap.react\shared\instances'
 @ ./shared/instances/newSwap.js 42:13-34
 @ ./shared/containers/App/App.js
 @ ./shared/containers/Root/Root.js
 @ ./client/index.js
i ｢wdm｣: Failed to compile.
```
Запуск npm скриптов происходит из корня, `process.cwd()` возвращает директорию из которой произошел запуск, т.е корень репозитория, и мы уходили на директорию выше. Т.к у меня не склонирован swap.core рядом с swap.react, то webpack ничего не нашел и выдавал ошибки.