### PR TITLE
Move footer from landing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/brands.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   <!--<script src="https://wiki.swap.online/ipfs.js" ></script>-->
   <script src="https://unpkg.com/ipfs@0.27.7/dist/index.js" ></script>
   <script src="https://wiki.swap.online/ipfs-pubsub-room.js" id="ipfsRoom"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-
+  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/brands.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   <!--<script src="https://wiki.swap.online/ipfs.js" ></script>-->
   <script src="https://unpkg.com/ipfs@0.27.7/dist/index.js" ></script>
   <script src="https://wiki.swap.online/ipfs-pubsub-room.js" id="ipfsRoom"></script>

--- a/shared/components/Footer/Footer.js
+++ b/shared/components/Footer/Footer.js
@@ -33,8 +33,6 @@ export default class Footer extends Component {
 
     const viewportBiggerThanPage = viewportHeight > pageHeight
 
-    console.log(viewportBiggerThanPage, viewportHeight, pageHeight)
-
     if (viewportBiggerThanPage) {
       return this.setFullFixed(true)
     }
@@ -70,6 +68,12 @@ export default class Footer extends Component {
   componentWillUnmount() {
     document.removeEventListener('scroll', this.calculateFooterHeight)
     window.removeEventListener('resize', this.calculateFooterHeight)
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if(prevProps.location.pathname !== this.props.location.pathname) {
+      this.calculateFooterHeight()
+    }
   }
 
   render() {

--- a/shared/components/Footer/Footer.js
+++ b/shared/components/Footer/Footer.js
@@ -1,30 +1,114 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import _ from 'lodash'
+import cx from 'classnames'
 import { connect } from 'redaction'
+import { withRouter } from 'react-router-dom'
 
 import CSSModules from 'react-css-modules'
 import styles from './Footer.scss'
 
 import Info from './Info/Info'
 import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
+import SocialMenu from './SocialMenu/SocialMenu'
 
+import logo from './images/logo.svg'
 
+@withRouter
 @connect(({ ipfs: { server, isOnline, onlineUsers } }) => ({
   server,
   isOnline,
   onlineUsers,
 }))
-@CSSModules(styles)
+@CSSModules(styles, { allowMultiple: true })
 export default class Footer extends Component {
+  state = { fixed: false, fullFixed: false }
+
+  __footerFullHeight = 0
+
+  calculateFooterHeight = () => {
+    const pageHeight = document.body.scrollHeight
+    const viewportHeight = document.documentElement.clientHeight
+    const scrolledHeight = document.documentElement.scrollTop
+
+    const pageWithoutFooter = pageHeight - (this.__footerFullHeight - this.infoFooterRef.clientHeight)
+
+    const viewportBiggerThanPage = viewportHeight > pageHeight
+
+    console.log(viewportBiggerThanPage, viewportHeight, pageHeight)
+
+    if (viewportBiggerThanPage) {
+      return this.setFullFixed(true)
+    }
+    this.setFullFixed(false)
+
+
+    if (pageWithoutFooter <= viewportHeight + scrolledHeight) {
+      this.setFixed(false)
+    } else {
+      this.setFixed(true)
+    }
+  }
+
+  setFullFixed = (value) => {
+    if (this.state.fullFixed !== value) {
+      this.setState({ fullFixed: value })
+    }
+  }
+
+  setFixed = (value) => {
+    if (this.state.fixed !== value) {
+      this.setState({ fixed: value })
+    }
+  }
+
+  componentDidMount() {
+    document.addEventListener('scroll', this.calculateFooterHeight)
+    window.addEventListener('resize', this.calculateFooterHeight)
+    this.__footerFullHeight = this.footerRef.clientHeight
+    this.calculateFooterHeight()
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('scroll', this.calculateFooterHeight)
+    window.removeEventListener('resize', this.calculateFooterHeight)
+  }
 
   render() {
     const { onlineUsers, isOnline, server } = this.props
+    const { fixed, fullFixed } = this.state
+
+    const informationFooterStyles = cx('information-footer', {
+      'fixed': fixed && !fullFixed,
+    })
+
+    const defaultFooterStyles = cx('default-footer', {
+      'margin': fixed && !fullFixed,
+    })
+
+    const footerStyles = cx('footer', {
+      'fixed': fullFixed,
+    })
 
     return (
-      <div styleName="footer">
-        <WidthContainer styleName="container">
-          <Info serverAddress={server} onlineUsers={onlineUsers} isOnline={isOnline} />
-          <span styleName="text" >Need help? Join Telegram chat <a href="https://t.me/swaponline" target="_blank" rel="noreferrer noopener">@swaponline</a></span>
-        </WidthContainer>
+      <div ref={(node) => this.footerRef = node} styleName={footerStyles}>
+        <div ref={(node) => this.infoFooterRef = node} styleName={informationFooterStyles}>
+          <WidthContainer styleName="container">
+            <Info serverAddress={server} onlineUsers={onlineUsers} isOnline={isOnline} />
+            <span styleName="text">
+              Need help? Join Telegram chat <a href="https://t.me/swaponline" target="_blank" rel="noreferrer noopener">@swaponline</a>
+            </span>
+          </WidthContainer>
+        </div>
+        <div styleName={defaultFooterStyles}>
+          <WidthContainer styleName="container">
+            <div styleName="copyright">
+              <img src={logo} styleName="copyright-logo" alt="logotype"/>
+              <span styleName="copyright-text">© 2018 Swap Online Harju maakond, Tallinn, Kesklinna linnaosa</span>
+            </div>
+            <SocialMenu />
+          </WidthContainer>
+        </div>
       </div>
     )
   }

--- a/shared/components/Footer/Footer.js
+++ b/shared/components/Footer/Footer.js
@@ -1,6 +1,4 @@
 import React, { Component } from 'react'
-import PropTypes from 'prop-types'
-import _ from 'lodash'
 import cx from 'classnames'
 import { connect } from 'redaction'
 import { withRouter } from 'react-router-dom'

--- a/shared/components/Footer/Footer.scss
+++ b/shared/components/Footer/Footer.scss
@@ -1,14 +1,30 @@
-.footer {
-  height: 44px;
-  width: 100%;
+$information-footer-height: 44px;
 
+.footer {
+  width: 100%;
   background: #ffffff;
 
-  position: fixed;
-  top: calc(100% - 44px);
-  left: 0;
-  right: 0;
-  z-index: 4;
+  &.fixed {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 4;
+  }
+}
+
+.information-footer {
+  width: 100%;
+  height: $information-footer-height;
+  background: #ffffff;
+
+  &.fixed {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 4;
+  }
 }
 
 .text {
@@ -20,4 +36,28 @@
   height: 100%;
   align-items: center;
   justify-content: space-between;
+}
+
+
+.default-footer {
+  padding-bottom: 8px;
+
+  &.margin {
+    margin-top: $information-footer-height;
+  }
+}
+
+.copyright {
+  display: flex;
+  align-items: center;
+
+  &-logo {
+    width: 40px;
+    height: 25px;
+  }
+
+  &-text {
+    font-size: 12px;
+    color: rgba(51, 51, 51, 0.6)
+  }
 }

--- a/shared/components/Footer/SocialMenu/SocialMenu.js
+++ b/shared/components/Footer/SocialMenu/SocialMenu.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import CSSModules from 'react-css-modules'
+import styles from './SocialMenu.scss'
+import links from 'helpers/links'
+
+@CSSModules(styles)
+export default class SocialMenu extends React.Component {
+  render() {
+    return (
+      <ul styleName="social-menu">
+        <li>
+          <a styleName="icon" href={links.medium}>
+            <i className="fab fa-medium-m" />
+          </a>
+        </li>
+        <li>
+          <a styleName="icon" href={links.twitter}>
+            <i styleName="icon" className="fab fa-twitter" />
+          </a>
+        </li>
+        <li>
+          <a styleName="icon" href={links.facebook}>
+            <i styleName="icon" className="fab fa-facebook-f" />
+          </a>
+        </li>
+        <li>
+          <a styleName="icon" href={links.telegram}>
+            <i styleName="icon" className="fab fa-telegram-plane" />
+          </a>
+        </li>
+        <li>
+          <a styleName="icon" href={links.bitcointalk}>
+            <i styleName="icon" className="fab fa-btc" />
+          </a>
+        </li>
+      </ul>
+    )
+  }
+}

--- a/shared/components/Footer/SocialMenu/SocialMenu.js
+++ b/shared/components/Footer/SocialMenu/SocialMenu.js
@@ -9,27 +9,27 @@ export default class SocialMenu extends React.Component {
     return (
       <ul styleName="social-menu">
         <li>
-          <a styleName="icon" href={links.medium}>
-            <i className="fab fa-medium-m" />
+          <a href={links.medium}>
+            <i styleName="icon" className="fab fa-medium-m" />
           </a>
         </li>
         <li>
-          <a styleName="icon" href={links.twitter}>
+          <a href={links.twitter}>
             <i styleName="icon" className="fab fa-twitter" />
           </a>
         </li>
         <li>
-          <a styleName="icon" href={links.facebook}>
+          <a href={links.facebook}>
             <i styleName="icon" className="fab fa-facebook-f" />
           </a>
         </li>
         <li>
-          <a styleName="icon" href={links.telegram}>
+          <a href={links.telegram}>
             <i styleName="icon" className="fab fa-telegram-plane" />
           </a>
         </li>
         <li>
-          <a styleName="icon" href={links.bitcointalk}>
+          <a href={links.bitcointalk}>
             <i styleName="icon" className="fab fa-btc" />
           </a>
         </li>

--- a/shared/components/Footer/SocialMenu/SocialMenu.scss
+++ b/shared/components/Footer/SocialMenu/SocialMenu.scss
@@ -1,0 +1,26 @@
+.social-menu {
+  display: flex;
+  align-items: center;
+  list-style: none;
+  margin: 0;
+
+  & li {
+    margin-right: 16px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+.icon {
+  color: #7371ff;
+  font-size: 20px;
+  text-align: center;
+  transition: color 300ms ease;
+
+
+  &:hover {
+    color: #e91db4;
+  }
+}

--- a/shared/components/Footer/SocialMenu/SocialMenu.scss
+++ b/shared/components/Footer/SocialMenu/SocialMenu.scss
@@ -18,7 +18,7 @@
   font-size: 20px;
   text-align: center;
   transition: color 300ms ease;
-
+  cursor: pointer;
 
   &:hover {
     color: #e91db4;

--- a/shared/components/Footer/images/logo.svg
+++ b/shared/components/Footer/images/logo.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="130px" height="120.86px" viewBox="71 70.367 130 120.86" enable-background="new 71 70.367 130 120.86"
+	 xml:space="preserve">
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-66.8787" y1="254.3187" x2="-67.242" y2="253.7082" gradientTransform="matrix(148 0 0 -137.594 10057.5996 35050.1641)">
+	<stop  offset="0" style="stop-color:#8820EE"/>
+	<stop  offset="1" style="stop-color:#500ED8"/>
+</linearGradient>
+<path fill="url(#SVGID_1_)" d="M71,85.602l30.469-15.235v120.86L71,181.069V85.602z M117.719,92.711l30.468-8.125v91.406
+	l-30.469-9.14L117.719,92.711L117.719,92.711z M164.438,102.867H201l-36.563,46.719V102.867z"/>
+</svg>

--- a/shared/containers/App/App.scss
+++ b/shared/containers/App/App.scss
@@ -1,6 +1,6 @@
 .main {
-	position: relative;
-	z-index: 1;
-	padding-top: 88px;
-  padding-bottom: 100px;
+  position: relative;
+  z-index: 1;
+  padding-top: 88px;
+  padding-bottom: 55px;
 }


### PR DESCRIPTION
Issue #281.
Вариант со плавающем футером и прилипающей частью с информацией показался мне наиболее удачным с точки зрения UX. Мы так же всегда видим информацию и при достижения конца страницы, информационная панель, сдвигается выше и под ней показывается футер с копирайтом и ссылками на медиа ресурсы, это на длинных страницах.
На коротких страницах, где нет полоски для скрола, сразу показывается полностью.