### PR TITLE
Fix link to testnet in production

### DIFF
--- a/shared/helpers/links.js
+++ b/shared/helpers/links.js
@@ -6,7 +6,7 @@ export default {
   feed: '/feed',
   affiliate: '/affiliate',
   listing: '/listing',
-  test: 'https:/testnet.swap.online',
+  test: 'https://testnet.swap.online',
   medium: 'https://medium.com/swaponline',
   twitter: 'https://twitter.com/SwapOnlineTeam',
   facebook: 'https://www.facebook.com/pg/Swaponline-637233326642691',


### PR DESCRIPTION
Исправил ссылку на testnet на https://swap.online
