### PR TITLE
Scroll screen to top after offer modal closes

### DIFF
--- a/shared/components/modals/OfferModal/OfferModal.js
+++ b/shared/components/modals/OfferModal/OfferModal.js
@@ -24,6 +24,10 @@ export default class Offer extends React.Component {
     offer: {},
   }
 
+  componentWillUnmount() {
+    window.scrollTo({top: 0})
+  }
+
   handleMoveToConfirmation = (offer) => {
     this.setState({
       view: 'confirmOffer',

--- a/shared/components/modals/OfferModal/OfferModal.js
+++ b/shared/components/modals/OfferModal/OfferModal.js
@@ -25,7 +25,7 @@ export default class Offer extends React.Component {
   }
 
   componentWillUnmount() {
-    window.scrollTo({top: 0})
+    window.scrollTo({ top: 0 })
   }
 
   handleMoveToConfirmation = (offer) => {


### PR DESCRIPTION
If the build is not going, the PR do not even look

* Match style guide 😏
  - [ ] [js](https://github.com/airbnb/javascript#ecmascript-6-es-2015-styles)
  - [x] [react](https://github.com/airbnb/javascript/tree/master/react)
  - [ ] [css/sass](https://github.com/airbnb/css)
* In the description issue 😋
  - [ ] https://github.com/swaponline/swap.react/issues/345
  - [ ] When Order Modal gets closed, scroll screen to the top, to get access to the main functionality
  - [ ] componentWillUnmount on modal component is chosen solution, because, screen must be scrolled to the top, after it gets closed.
* Git 😈
  - [ ] [The rebase master is done](https://git-scm.com/book/en/v2/Git-Branching-Rebasing)
  `git pull --rebase origin master`

For the correct PR bonus tokens ✨ <br>
💔Thank you!

