### PR TITLE
Адаптация таблицы Wallet для мобильного просмотра #2

### DIFF
--- a/shared/components/Header/NavMobile/NavMobile.js
+++ b/shared/components/Header/NavMobile/NavMobile.js
@@ -14,36 +14,23 @@ export default class NavMobile extends Component {
     menu: PropTypes.array.isRequired,
   }
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      isOpened: false,
-    }
-  }
-
-  handleToggle = () => {
-    this.setState({
-      isOpened: !this.state.isOpened,
-    })
-  }
-
   render() {
-    const { props: { menu }, state: { isOpened } } = this
+    const { props: { menu } } = this
 
     return (
       <div styleName="navbar">
         {
           menu
             .filter(i => i.isMobile !== false)
-            .map(({ title, link, exact }) => (
+            .map(({ title, link, exact, icon }) => (
               <NavLink
-                exact={exact}
                 key={title}
+                exact={exact}
                 to={link}
                 activeClassName={styles.active}
-                onClick={this.handleToggle}
               >
-                {title}
+                <i className={`fas fa-${icon}`} aria-hidden="true" />
+                <span>{title}</span>
               </NavLink>
             ))
         }

--- a/shared/components/Header/NavMobile/NavMobile.scss
+++ b/shared/components/Header/NavMobile/NavMobile.scss
@@ -13,28 +13,31 @@
 	background: -moz-linear-gradient(left, #510ed8 0%, #510ed8 70%, #8821ee 100%); /* FF3.6-15 */
 	background: -webkit-linear-gradient(left, #510ed8 0%,#510ed8 70%,#8821ee 100%); /* Chrome10-25,Safari5.1-6 */
 	background: linear-gradient(to right, #510ed8 0%,#510ed8 70%,#8821ee 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
-	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#510ed8', endColorstr='#8821ee',GradientType=1 ); /* IE6-9 */
+  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#510ed8', endColorstr='#8821ee',GradientType=1 ); /* IE6-9 */
 
   a {
     display: block;
-    color: #dccef7;
-    text-align: center;
-    padding: 14px 16px;
-    text-decoration: none;
     font-size: 17px;
     flex: 1;
+    padding: 14px 16px;
+    text-align: center;
+    color: #dccef7;
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
 
     &.active {
-      border-bottom: 2px solid #fff;
       font-weight: 700;
       color: #fff;
     }
 
+    i {
+      padding: 5px 0;
+    }
   }
 }
 
 .active {
-  border-bottom: 2px solid #fff;
   font-weight: 700;
   color: #fff;
 }

--- a/shared/components/QR/QR.js
+++ b/shared/components/QR/QR.js
@@ -1,0 +1,24 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+/**
+ * @todo Amount support?
+ */
+export default class QR extends Component {
+  static propTypes = {
+    network: PropTypes.string.isRequired,
+    address: PropTypes.string.isRequired,
+    size: PropTypes.number
+  }
+
+  render() {
+    const { network, address, size = 250 } = this.props
+
+    return (
+      <img
+        src={`https://chart.googleapis.com/chart?chs=${size}x${size}&cht=qr&chl=${network}:${address}`}
+        alt={`${network}: ${address}`}
+      />
+    )
+  }
+}

--- a/shared/components/Table/Table.js
+++ b/shared/components/Table/Table.js
@@ -9,7 +9,7 @@ const Table = ({ titles, rows, rowRender, classTitle, textIfEmpty, isLoading, lo
     <thead>
       <tr>
         {
-          titles.map((title, index) => (
+          titles.filter(title => !!title).map((title, index) => (
             <th key={index}>{title}</th>
           ))
         }

--- a/shared/components/modal/Modal/Modal.js
+++ b/shared/components/modal/Modal/Modal.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import ClickOutside from 'react-click-outside'
 
 import actions from 'redux/actions'
 import PropTypes from 'prop-types'
@@ -59,39 +60,43 @@ export default class Modal extends Component {
   }
 
   render() {
-    const { className, whiteLogo, title, showCloseButton, disableClose, children, titleUppercase } = this.props
+    const { className, whiteLogo, title, showCloseButton, disableClose, children, titleUppercase, name } = this.props
 
     const titleStyleName = cx('title', {
       'uppercase': titleUppercase,
     })
 
     return (
-      <Overlay>
-        <div styleName="modal" className={className}>
-          {
-            Boolean(title || showCloseButton) && (
-              <div styleName="header">
-                <WidthContainer styleName="headerContent">
-                  <Logo colored={!whiteLogo} />
-                  <div styleName={titleStyleName} role="title">{title}</div>
-                  {
-                    showCloseButton && !disableClose && (
-                      <CloseIcon styleName="closeButton" onClick={this.close} data-testid="modalCloseIcon" />
-                    )
-                  }
-                </WidthContainer>
-              </div>
-            )
-          }
-          <div styleName="contentContainer">
-            <Center scrollable>
-              <div styleName="content">
-                {children}
-              </div>
-            </Center>
+      <ClickOutside onClickOutside={() => {
+        actions.modals.close(name)
+      }}>
+        <Overlay>
+          <div styleName="modal" className={className}>
+            {
+              Boolean(title || showCloseButton) && (
+                <div styleName="header">
+                  <WidthContainer styleName="headerContent">
+                    <Logo colored={!whiteLogo} />
+                    <div styleName={titleStyleName} role="title">{title}</div>
+                    {
+                      showCloseButton && !disableClose && (
+                        <CloseIcon styleName="closeButton" onClick={this.close} data-testid="modalCloseIcon" />
+                      )
+                    }
+                  </WidthContainer>
+                </div>
+              )
+            }
+            <div styleName="contentContainer">
+              <Center scrollable>
+                <div styleName="content">
+                  {children}
+                </div>
+              </Center>
+            </div>
           </div>
-        </div>
-      </Overlay>
+        </Overlay>
+      </ClickOutside>
     )
   }
 }

--- a/shared/components/modals/ReceiveModal/ReceiveModal.js
+++ b/shared/components/modals/ReceiveModal/ReceiveModal.js
@@ -1,0 +1,67 @@
+import React from 'react'
+import CopyToClipboard from 'react-copy-to-clipboard'
+
+import cssModules from 'react-css-modules'
+import styles from './ReceiveModal.scss'
+
+import QR from 'components/QR/QR'
+import { Modal } from 'components/modal'
+import { Button } from 'components/controls'
+
+
+@cssModules(styles)
+export default class ReceiveModal extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      isAddressCopied: false
+    }
+  }
+
+  handleCopyAddress = () => {
+    this.setState({
+      isAddressCopied: true,
+    }, () => {
+      setTimeout(() => {
+        this.setState({
+          isAddressCopied: false,
+        })
+      }, 500)
+    })
+  }
+
+  render() {
+    const { props: { name, data: { currency, address } }, state: { isAddressCopied } } = this
+
+    return (
+      <Modal name={name} title="Receive">
+        <div styleName="content">
+          <p>This is your address for receive {currency}</p>
+          <CopyToClipboard
+            text={address}
+            onCopy={this.handleCopyAddress}
+          >
+            <p>
+              <QR
+                network={currency}
+                address={address}
+                size={500}
+              />
+              {address}
+              <Button
+                styleName="button"
+                brand
+                onClick={() => {}}
+                disabled={isAddressCopied}
+                fullWidth
+              >
+                { isAddressCopied ? 'Address copied to clipboard' : 'Copy to clipboard' }
+              </Button>
+            </p>
+          </CopyToClipboard>
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/shared/components/modals/ReceiveModal/ReceiveModal.scss
+++ b/shared/components/modals/ReceiveModal/ReceiveModal.scss
@@ -1,0 +1,12 @@
+.button {
+  margin-top: 40px;
+}
+
+.content {
+  margin: 0;
+  word-break: break-word;
+
+  img {
+    width: 100%;
+  }
+}

--- a/shared/components/modals/index.js
+++ b/shared/components/modals/index.js
@@ -5,6 +5,7 @@ import EosModal from './EosModal/EosModal'
 import Approve from './Approve/Approve'
 import ImportKeys from './ImportKeys/ImportKeys'
 import EthChecker from './EthChecker/EthChecker'
+import ReceiveModal from './ReceiveModal/ReceiveModal'
 
 
 export default {
@@ -15,4 +16,5 @@ export default {
   EosModal,
   Approve,
   EthChecker,
+  ReceiveModal,
 }

--- a/shared/components/tables/Table/Table.js
+++ b/shared/components/tables/Table/Table.js
@@ -21,7 +21,7 @@ export default class Table extends React.Component {
         <thead>
           <tr>
             {
-              titles.map((title, index) => (
+              titles.filter(title => !!title).map((title, index) => (
                 <th key={index}>{title}</th>
               ))
             }

--- a/shared/components/tables/Table/Table.scss
+++ b/shared/components/tables/Table/Table.scss
@@ -32,6 +32,14 @@
     &:last-child {
       padding-right: 0;
     }
+
+    div {
+      button {
+        i {
+          display: none;
+        }
+      }
+    }
   }
 
   th {
@@ -58,68 +66,68 @@
   // Wallet
   .wallet {
     & td {
-      &:first-child {
-        position: absolute;
-        z-index: 2;
-        background: $color-f-brightest;
-      }
+      // &:first-child {
+      //   position: absolute;
+      //   z-index: 2;
+      //   background: $color-f-brightest;
+      // }
 
-      &:nth-child(2) {
-        position: absolute;
-        z-index: 2;
-        left: 90px;
-        background: $color-f-brightest;
-        height: 80px;
-        padding-top: 28px;
-        max-width: 146px;
-        min-width: 100px;
-      }
+      // &:nth-child(2) {
+      //   position: absolute;
+      //   z-index: 2;
+      //   left: 90px;
+      //   background: $color-f-brightest;
+      //   height: 80px;
+      //   padding-top: 28px;
+      //   max-width: 146px;
+      //   min-width: 100px;
+      // }
 
-      &:nth-child(3) {
-        min-width: 80px;
-        display: flex;
-        margin-left: 150px;
-        height: 80px;
-        align-items: center;
-      }
+      // &:nth-child(3) {
+      //   min-width: 80px;
+      //   display: flex;
+      //   margin-left: 150px;
+      //   height: 80px;
+      //   align-items: center;
+      // }
     }
 
     & th {
-      &:first-child {
-        position: absolute;
-        display: flex;
-        background: $color-f-brightest;
-        align-items: center;
-        height: 40px;
-        width: 50px;
-      }
+      // &:first-child {
+      //   position: absolute;
+      //   display: flex;
+      //   background: $color-f-brightest;
+      //   align-items: center;
+      //   height: 40px;
+      //   width: 50px;
+      // }
 
-      &:nth-child(2) {
-        position: absolute;
-        display: flex;
-        background: $color-f-brightest;
-        align-items: center;
-        height: 40px;
-        width: 100px;
-        left: 90px;
-      }
+      // &:nth-child(2) {
+      //   position: absolute;
+      //   display: flex;
+      //   background: $color-f-brightest;
+      //   align-items: center;
+      //   height: 40px;
+      //   width: 100px;
+      //   left: 90px;
+      // }
 
-      &:nth-child(3) {
-        margin-left: 150px;
-        display: flex;
-      }
+      // &:nth-child(3) {
+      //   margin-left: 150px;
+      //   display: flex;
+      // }
     }
 
     & tr:first-child td:first-child {
-      padding-top: 15px;
-      height: 75px;
-      margin-top: 5px;
+      // padding-top: 15px;
+      // height: 75px;
+      // margin-top: 5px;
     }
 
     & tr:first-child td:nth-child(2) {
-      padding-top: 23px;
-      height: 75px;
-      margin-top: 5px;
+      // padding-top: 23px;
+      // height: 75px;
+      // margin-top: 5px;
     }
   }
 
@@ -219,16 +227,37 @@
 
 @include media-mobile {
   table {
-    // font-size: 14px;
+    overflow-x: auto;
   }
 
-  .wallet {
-    td:nth-child(2) {
-      left: 70px;
-    }
+  table.wallet {
 
-    th:nth-child(2) {
-      left: 70px;
+    td {
+
+      &>i {
+        display: none;
+      }
+
+      div {
+
+        button {
+
+          width: 40px;
+          padding: 1px 7px 2px 7px;
+          margin: 0 1px;
+
+          i {
+            display: block;
+          }
+
+          span {
+            display: none;
+          }
+
+        }
+
+      }
+
     }
   }
 }

--- a/shared/containers/App/App.js
+++ b/shared/containers/App/App.js
@@ -5,6 +5,7 @@ import actions from 'redux/actions'
 import { connect } from 'redaction'
 import moment from 'moment-with-locales-es6'
 import { constants, localStorage } from 'helpers'
+import { isMobile } from 'react-device-detect'
 
 import CSSModules from 'react-css-modules'
 import styles from './App.scss'
@@ -120,12 +121,12 @@ export default class App extends React.Component {
         <Seo location={history.location} />
         <Header />
         <WidthContainer styleName="main">
-          <main style={{ marginTop: '88px' }}>
+          <main>
             {children}
           </main>
         </WidthContainer>
         <Core />
-        <Footer />
+        { !isMobile && <Footer /> }
         <RequestLoader />
         <ModalConductor />
         <NotificationConductor />

--- a/shared/containers/App/App.scss
+++ b/shared/containers/App/App.scss
@@ -3,10 +3,19 @@
   z-index: 1;
   padding-bottom: 55px;
   margin-top: 88px;
+
+  main {
+    margin-top: 88px;
+  }
 }
 
 @include media-mobile {
 	.main {
-		padding-bottom: 30px;
+    padding-bottom: 30px;
+
+    main {
+      margin-top: 0;
+    }
+
 	}
 }

--- a/shared/helpers/constants/modals.js
+++ b/shared/helpers/constants/modals.js
@@ -6,4 +6,5 @@ export default {
   Approve: 'Approve',
   ImportKeys: 'ImportKeys',
   EthChecker: 'EthChecker',
+  ReceiveModal: 'ReceiveModal',
 }

--- a/shared/pages/Wallet/Row/Row.js
+++ b/shared/pages/Wallet/Row/Row.js
@@ -1,6 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import actions from 'redux/actions'
 import { constants } from 'helpers'
+import { isMobile } from 'react-device-detect'
 
 import cssModules from 'react-css-modules'
 import styles from './Row.scss'
@@ -90,6 +91,15 @@ export default class Row extends Component {
     })
   }
 
+  handleReceive = () => {
+    const { currency, address } = this.props
+
+    actions.modals.open(constants.modals.ReceiveModal, {
+      currency,
+      address,
+    })
+  }
+
   handleGoTrade = async (link) => {
     const balance = await actions.eth.getBalance()
 
@@ -116,8 +126,8 @@ export default class Row extends Component {
         <td>
           <Coin name={currency} size={40} />
         </td>
-        <td>{currency}</td>
-        <td style={{ minWidth: '120px' }}>
+        { !isMobile && <td>{currency}</td> }
+        <td>
           {
             !isBalanceFetched || isBalanceFetching ? (
               <InlineLoader />
@@ -135,38 +145,56 @@ export default class Row extends Component {
             )
           }
         </td>
-        <CopyToClipboard
-          text={address}
-          onCopy={this.handleCopyAddress}
-        >
-          <td style={{ position: 'relative' }}>
-            {
-              !contractAddress ? (
-                <Fragment>
-                  { currency !== 'EOS' && <i className="far fa-copy" styleName="icon" /> }
-                  <LinkAccount type={currency} address={address} >{address}</LinkAccount>
-                </Fragment>
-              ) : (
-                <Fragment>
-                  <i className="far fa-copy" styleName="icon" />
-                  <LinkAccount type={currency} contractAddress={contractAddress} address={address} >{address}</LinkAccount>
-                </Fragment>
-              )
-            }
-            {
-              currency === 'EOS' && address === '' && <button styleName="button" onClick={this.handleEosLogin}>Login</button>
-            }
-            { isAddressCopied && <p styleName="copied" >Address copied to clipboard</p> }
-          </td>
-        </CopyToClipboard>
-        <td >
+        { !isMobile && (
+          <CopyToClipboard
+            text={address}
+            onCopy={this.handleCopyAddress}
+          >
+            <td style={{ position: 'relative' }}>
+              {
+                !contractAddress ? (
+                  <Fragment>
+                    { currency !== 'EOS' && <i className="far fa-copy" styleName="icon" /> }
+                    <LinkAccount type={currency} address={address} >{address}</LinkAccount>
+                  </Fragment>
+                ) : (
+                  <Fragment>
+                    <i className="far fa-copy" styleName="icon" />
+                    <LinkAccount type={currency} contractAddress={contractAddress} address={address} >{address}</LinkAccount>
+                  </Fragment>
+                )
+              }
+              {
+                currency === 'EOS' && address === '' && <button styleName="button" onClick={this.handleEosLogin}>Login</button>
+              }
+              { isAddressCopied && <p styleName="copied" >Address copied to clipboard</p> }
+            </td>
+          </CopyToClipboard>
+        ) }
+        <td>
           <div>
-            <WithdrawButton onClick={this.handleWithdraw} styleName="marginRight" >
-              Send
+            { isMobile && (
+              <WithdrawButton onClick={this.handleReloadBalance} styleName="marginRight">
+                <i className="fas fa-sync-alt" />
+                <span>Refresh</span>
+              </WithdrawButton>
+            ) }
+            <WithdrawButton onClick={this.handleWithdraw} styleName="marginRight">
+              <i className="fas fa-arrow-alt-circle-down" />
+              <span>Send</span>
             </WithdrawButton>
+            { isMobile && (
+              <WithdrawButton onClick={this.handleReceive} styleName="marginRight">
+                <i className="fas fa-arrow-alt-circle-up" />
+                <span>Receive</span>
+              </WithdrawButton>
+            )}
             {
               tradeAllowed && (
-                <div styleName="button" onClick={() => this.handleGoTrade(`/${currency.toLowerCase()}`)}>Swap</div>
+                <WithdrawButton onClick={() => this.handleGoTrade(`/${currencyFullTitle.toLowerCase()}`)}>
+                  <i className="fas fa-exchange-alt" />
+                  <span>Swap</span>
+                </WithdrawButton>
               )
             }
           </div>

--- a/shared/pages/Wallet/Wallet.js
+++ b/shared/pages/Wallet/Wallet.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import { isMobile } from 'react-device-detect'
 
 import { connect } from 'redaction'
 import { constants } from 'helpers'
@@ -11,6 +12,7 @@ import SaveKeys from 'components/SaveKeys/SaveKeys'
 import PageHeadline from 'components/PageHeadline/PageHeadline'
 import SubTitle from 'components/PageHeadline/SubTitle/SubTitle'
 import { WithdrawButton } from 'components/controls'
+import stylesWallet from './Wallet.scss'
 
 import Row from './Row/Row'
 
@@ -70,7 +72,7 @@ export default class Wallet extends Component {
   render() {
     const { view } = this.state
     const { items, tokens, currencies } = this.props
-    const titles = [ 'Coin', 'Name', 'Balance', 'Address', 'Actions' ]
+    const titles = [ 'Coin', !isMobile && 'Name', 'Balance', !isMobile && 'Address', 'Actions' ]
 
     return (
       <section>

--- a/shared/redux/reducers/menu.js
+++ b/shared/redux/reducers/menu.js
@@ -7,14 +7,17 @@ export const initialState = {
       title: 'Wallet',
       link: links.home,
       exact: true,
+      icon: 'wallet',
     },
     {
       title: 'Exchange',
       link: links.exchange,
+      icon: 'exchange-alt',
     },
     {
       title: 'History',
       link: links.history,
+      icon: 'history',
     },
     {
       title: 'Affiliate',


### PR DESCRIPTION
* Спрятан футер в мобильном просмотре
* Добавлена возможность скрыть заголовки таблицы для мобильного просмотра
* Некоторые фиксы для стайлинга таблиц (старые стили закомментированы, а не удалены. для дальнейшего удобства)
* Добавлены иконки в мобильное меню
* Добавлена реакция на клик Receive кнопки в Wallet
* Добавлен компонент `QR` для отображения QR кода @noxonsu Здесь надо бы проверить, особенно для не Bitcoin/Ethereum
* Закрывать модальные окна при клике извне (например, если кликнуть на мобильное меню при открытом диалоге `Receive` - меню переключится, но диалог останется висеть)
* Исправлены ошибки стилей, присутствовавшие в первом варианте пулл реквеста

