### PR TITLE
Уведомления о свапе в мобильном режиме

### DIFF
--- a/shared/components/Header/User/User.js
+++ b/shared/components/Header/User/User.js
@@ -1,7 +1,4 @@
 import React from 'react'
-
-import { withRouter } from 'react-router'
-import actions from 'redux/actions'
 import { connect } from 'redaction'
 
 import styles from './User.scss'
@@ -13,7 +10,6 @@ import UserTooltip from './UserTooltip/UserTooltip'
 import AddOfferButton from './AddOfferButton/AddOfferButton'
 
 
-@withRouter
 @connect({
   feeds: 'feeds.items',
   peer: 'ipfs.peer',
@@ -35,32 +31,15 @@ export default class User extends React.Component {
     })
   }
 
-  declineRequest = (orderId, participantPeer) => {
-    actions.core.declineRequest(orderId, participantPeer)
-    actions.core.updateCore()
-  }
-
-  acceptRequest = (orderId, participantPeer) => {
-    actions.core.acceptRequest(orderId, participantPeer)
-    actions.core.updateCore()
-    this.handleToggleTooltip()
-  }
-
-  autoAcceptRequest = (orderId, participantPeer, link) => {
-    this.acceptRequest(orderId, participantPeer)
-    this.props.history.push(link)
-  }
-
   soundClick = () => {
     let audio = new Audio()
     audio.src = Sound
     audio.autoplay = true
   }
 
-
   render() {
     const { view } = this.state
-    const { feeds, peer } = this.props
+    const { feeds } = this.props
 
     return (
       <div styleName="user-cont">
@@ -73,12 +52,7 @@ export default class User extends React.Component {
         />
         {
           view && <UserTooltip
-            view={view}
-            feeds={feeds}
-            mePeer={peer}
-            autoAcceptRequest={this.autoAcceptRequest}
-            acceptRequest={this.acceptRequest}
-            declineRequest={this.declineRequest}
+            toggle={this.handleToggleTooltip}
           />
         }
       </div>

--- a/shared/components/Header/User/UserTooltip/UserTooltip.js
+++ b/shared/components/Header/User/UserTooltip/UserTooltip.js
@@ -1,7 +1,11 @@
-import React from 'react'
-
+import React, { Component } from 'react'
+import { connect } from 'redaction'
+import { withRouter } from 'react-router'
 import PropTypes from 'prop-types'
+
 import { TimerButton } from 'components/controls'
+
+import actions from 'redux/actions'
 
 import { links } from 'helpers'
 import { Link } from 'react-router-dom'
@@ -12,46 +16,72 @@ import styles from './UserTooltip.scss'
 import ArrowRightSvg from './images/arrow-right.svg'
 
 
-const UserTooltip = ({ feeds, mePeer, acceptRequest, view, autoAcceptRequest, declineRequest }) => (
-  <div styleName="column" >
-    { view && feeds.length < 3  ? (
-      feeds.map(row => {
-        const { request, content: { buyAmount, buyCurrency, sellAmount, sellCurrency },  id, peer: ownerPeer } = row
+@withRouter
+@connect({
+  feeds: 'feeds.items',
+  peer: 'ipfs.peer',
+})
+@CSSModules(styles)
+export default class UserTooltip extends Component {
 
-        return (
-          mePeer === ownerPeer &&
-          request.map(({ peer, reputation }) => (
-            <div styleName="userTooltip" >
-              <div key={peer}>
-                <div styleName="title">User with <b>{reputation}</b> reputation wants to swap</div>
-                <div styleName="currency">
-                  <span>{buyAmount.toFixed(5)} <span styleName="coin">{buyCurrency}</span></span>
-                  <span styleName="arrow"><img src={ArrowRightSvg} alt="" /></span>
-                  <span>{sellAmount.toFixed(5)} <span styleName="coin">{sellCurrency}</span></span>
+  static propTypes = {
+    toggle: PropTypes.func
+  }
+
+  declineRequest = (orderId, participantPeer) => {
+    actions.core.declineRequest(orderId, participantPeer)
+    actions.core.updateCore()
+  }
+
+  acceptRequest = (orderId, participantPeer) => {
+    const { toggle } = this.props
+
+    actions.core.acceptRequest(orderId, participantPeer)
+    actions.core.updateCore()
+    !!toggle && toggle()
+  }
+
+  autoAcceptRequest = (orderId, participantPeer, link) => {
+    this.acceptRequest(orderId, participantPeer)
+    this.props.history.push(link)
+  }
+
+  render() {
+    const { feeds, peer: mePeer } = this.props
+
+    return !!feeds.length && (
+      <div styleName="column" >
+        { feeds.length < 3  ? (
+          feeds.map(row => {
+            const { request, content: { buyAmount, buyCurrency, sellAmount, sellCurrency }, id, peer: ownerPeer } = row
+
+            return (
+              mePeer === ownerPeer &&
+              request.map(({ peer, reputation }) => (
+                <div styleName="userTooltip" >
+                  <div key={peer}>
+                    <div styleName="title">User with <b>{reputation}</b> reputation wants to swap</div>
+                    <div styleName="currency">
+                      <span>{buyAmount.toFixed(5)} <span styleName="coin">{buyCurrency}</span></span>
+                      <span styleName="arrow"><img src={ArrowRightSvg} alt="" /></span>
+                      <span>{sellAmount.toFixed(5)} <span styleName="coin">{sellCurrency}</span></span>
+                    </div>
+                  </div>
+                  <span styleName="decline" onClick={() => this.declineRequest(id, peer)} />
+                  <Link to={`${links.swap}/${sellCurrency}-${buyCurrency}/${id}`}>
+                    <div styleName="checked" onClick={() => this.acceptRequest(id, peer)} />
+                  </Link>
+                  <TimerButton isButton={false} onClick={() => this.autoAcceptRequest(id, peer, `${links.swap}/${sellCurrency}-${buyCurrency}/${id}`)} />
                 </div>
-              </div>
-              <span styleName="decline" onClick={() => declineRequest(id, peer)} />
-              <Link to={`${links.swap}/${sellCurrency}-${buyCurrency}/${id}`}>
-                <div styleName="checked" onClick={() => acceptRequest(id, peer)} />
-              </Link>
-              <TimerButton isButton={false} onClick={() => autoAcceptRequest(id, peer, `${links.swap}/${sellCurrency}-${buyCurrency}/${id}`)} />
-            </div>
-          ))
-        )
-      })
-    ) : (
-      <div styleName="feed" >
-        <Link to={links.feed} > Go to the feed page</Link>
+              ))
+            )
+          })
+        ) : (
+          <div styleName="feed" >
+            <Link to={links.feed} > Go to the feed page</Link>
+          </div>
+        )}
       </div>
-    )}
-  </div>
-)
-
-
-UserTooltip.propTypes = {
-  feeds: PropTypes.array,
-  mePeer: PropTypes.string,
-  acceptRequest: PropTypes.func,
+    )
+  }
 }
-
-export default CSSModules(UserTooltip, styles, { allowMultiple: true })

--- a/shared/components/Header/User/UserTooltip/UserTooltip.scss
+++ b/shared/components/Header/User/UserTooltip/UserTooltip.scss
@@ -3,6 +3,7 @@
   min-width: 360px;
   top: 68px;
   right: 0;
+  z-index: 1024;
 }
 
 .feed {

--- a/shared/containers/App/App.js
+++ b/shared/containers/App/App.js
@@ -24,6 +24,7 @@ import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
 import NotificationConductor from 'components/notification/NotificationConductor/NotificationConductor'
 import Seo from 'components/Seo/Seo'
 import ErrorNotification from 'components/notification/ErrorNotification/ErrorNotification'
+import UserTooltip from 'components/Header/User/UserTooltip/UserTooltip'
 
 
 const userLanguage = (navigator.userLanguage || navigator.language || 'en-gb').split('-')[0]
@@ -119,6 +120,7 @@ export default class App extends React.Component {
       <Fragment>
         {error && <ErrorNotification hideErrorNotification={this.hideErrorNotification} error={error} />}
         <Seo location={history.location} />
+        { isMobile && <UserTooltip /> }
         <Header />
         <WidthContainer styleName="main">
           <main>

--- a/shared/containers/App/App.scss
+++ b/shared/containers/App/App.scss
@@ -13,6 +13,8 @@
 	.main {
     padding-bottom: 30px;
 
+    margin-top: 0;
+
     main {
       margin-top: 0;
     }


### PR DESCRIPTION
Исправление бага #411 

* `UserTooltip` теперь контейнер, а не функция
* Так как `Header` не рендерится для мобильного режима, выводим `UserTooltip` напрямую
* Внешний вид не изменен, выводится как ранее

```просто пусть появляется, потом после практического использования поймем как делать```

![localhost_9001_ iphone x](https://user-images.githubusercontent.com/856260/44988842-5f7e3d80-afcf-11e8-8dad-26991f0177b1.png)
