### PR TITLE
Корректное наименование приложения

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swap.react",
+  "name": "swap.online",
   "version": "1.0.0",
   "description": "swap.online",
   "private": true,


### PR DESCRIPTION
При размещении сайта на домашний экран айфона выводится неверное наименование `swap.react`, а не `swap.online`

![img_4546](https://user-images.githubusercontent.com/856260/45065275-905b9100-b0fb-11e8-94a2-9429e55fa29f.PNG)
