### PR TITLE
Мобильные улучшения

### DIFF
--- a/shared/components/tables/Table/Table.scss
+++ b/shared/components/tables/Table/Table.scss
@@ -90,6 +90,7 @@
       //   height: 80px;
       //   align-items: center;
       // }
+      padding: 15px 10px;
     }
 
     & th {
@@ -116,6 +117,7 @@
       //   margin-left: 150px;
       //   display: flex;
       // }
+      padding: 15px 10px;
     }
 
     & tr:first-child td:first-child {

--- a/shared/containers/App/App.scss
+++ b/shared/containers/App/App.scss
@@ -14,9 +14,11 @@
     padding-bottom: 30px;
 
     margin-top: 0;
+    margin-bottom: 80px;
 
     main {
       margin-top: 0;
+      margin-bottom: 80px;
     }
 
 	}

--- a/shared/pages/Wallet/Row/Row.js
+++ b/shared/pages/Wallet/Row/Row.js
@@ -138,7 +138,7 @@ export default class Row extends Component {
         <td>
           <CoinInteractive onHide={this.handleMarkCoinAsHidden} name={currency} size={40} />
         </td>
-        { !isMobile && <td>{currency}</td> }
+        <td>{currency}</td>
         <td>
           {
             !isBalanceFetched || isBalanceFetching ? (
@@ -146,7 +146,7 @@ export default class Row extends Component {
             ) : (
               <Fragment>
                 <i className="fas fa-sync-alt" styleName="icon" onClick={this.handleReloadBalance} />
-                <span>{String(balance).length > 5 ? balance.toFixed(5) : balance}</span>
+                <span>{String(balance).length > 4 ? balance.toFixed(4) : balance}</span>
                 { currency === 'BTC' && currency === 'USDT' && unconfirmedBalance !== 0 && (
                   <Fragment>
                     <br />

--- a/shared/pages/Wallet/Wallet.js
+++ b/shared/pages/Wallet/Wallet.js
@@ -80,7 +80,7 @@ export default class Wallet extends Component {
   render() {
     const { view } = this.state
     const { items, tokens, currencies, hiddenCoinsList } = this.props
-    const titles = [ 'Coin', !isMobile && 'Name', 'Balance', !isMobile && 'Address', isMobile ? 'Receive, send, swap' :  'Actions' ]
+    const titles = [ 'Coin', 'Name', 'Balance', !isMobile && 'Address', isMobile ? 'Receive, send, swap' :  'Actions' ]
 
     return (
       <section>


### PR DESCRIPTION
* Показывать наименование валюты
* Уменьшен паддинг для ячеек таблицы при мобильном просмотре
* Баланс валют округляется до 4 цифр после запятой
* Увеличен `margin-bottom` для контейнера

![localhost_9001_ iphone x](https://user-images.githubusercontent.com/856260/45096231-68a01380-b163-11e8-9236-f497fb56b511.png)
![localhost_9001_ iphone x 1](https://user-images.githubusercontent.com/856260/45096232-68a01380-b163-11e8-8319-6e1f3a4cf8c5.png)
