### PR TITLE
Issue 526 exchange underline

### DIFF
--- a/shared/components/Header/Header.js
+++ b/shared/components/Header/Header.js
@@ -12,7 +12,8 @@ import NavMobile from './NavMobile/NavMobile'
 import Logo from 'components/Logo/Logo'
 import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
 
-let lastScrollTop = 0;
+
+let lastScrollTop = 0
 
 @withRouter
 @connect(({ menu: { items: menu } }) => ({
@@ -27,27 +28,27 @@ export default class Header extends Component {
     super()
 
     this.state = {
-      sticky: false
+      sticky: false,
     }
   }
 
   componentDidMount() {
-    window.addEventListener('scroll', this.handleScroll);
-  };
+    window.addEventListener('scroll', this.handleScroll)
+  }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', this.handleScroll);
-  };
+    window.removeEventListener('scroll', this.handleScroll)
+  }
 
   handleScroll = () =>  {
-    let scrollTop = window.pageYOffset || document.documentElement.scrollTop;
-      if ( scrollTop > lastScrollTop || scrollTop < 88) {
-        this.setState(() => ({sticky: false}))
-      }
-      else {
-        this.setState(() => ({sticky: true}))
-      }
-      lastScrollTop = scrollTop;
+    let scrollTop = window.pageYOffset || document.documentElement.scrollTop
+    if (scrollTop > lastScrollTop || scrollTop < 88) {
+      this.setState(() => ({ sticky: false }))
+    }
+    else {
+      this.setState(() => ({ sticky: true }))
+    }
+    lastScrollTop = scrollTop
   }
 
   render() {
@@ -59,7 +60,7 @@ export default class Header extends Component {
     }
 
     return (
-      <div styleName={sticky ? 'header header-fixed': 'header'}>
+      <div styleName={sticky ? 'header header-fixed' : 'header'}>
         <WidthContainer styleName="container">
           <Logo withLink />
           <Nav menu={menu} />

--- a/shared/components/Header/Nav/Nav.js
+++ b/shared/components/Header/Nav/Nav.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
 import { NavLink } from 'react-router-dom'
 import { links } from 'helpers'
@@ -8,14 +9,34 @@ import CSSModules from 'react-css-modules'
 import styles from './Nav.scss'
 
 
-@CSSModules(styles)
+@CSSModules(styles, { allowMultiple: true })
 export default class Nav extends Component {
 
   static propTypes = {
     menu: PropTypes.array.isRequired,
   }
 
-  handleClick = () => {
+  state = {
+    activeRoute: '/',
+  }
+
+  componentDidMount = () => {
+    const path = window.location.pathname
+    const menu = document.querySelector('#navmenu')
+    const el = menu.querySelector(`a[href="${path}"]`)
+
+    // TODO: Replace this hack approach
+
+    if (el) {
+      el.click()
+    } else {
+      menu.querySelector('a[href="/exchange"]').click()
+    }
+  }
+
+  handleClick = (link) => {
+    this.setState({ activeRoute: link })
+
     const scrollStep = -window.scrollY / (500 / 15)
     const scrollInterval = setInterval(() => {
       if (window.scrollY !== 0) {
@@ -28,21 +49,22 @@ export default class Nav extends Component {
 
   render() {
     const { menu } = this.props
+    const { activeRoute } = this.state
 
     return (
-      <div styleName="nav">
+      <div id="navmenu" styleName="nav">
         <Fragment>
           {
             menu
               .filter(i => i.isDesktop !== false)
               .map(({ title, link, exact }) => (
                 <NavLink
-                  onClick={this.handleClick}
+                  onClick={() => this.handleClick(link)}
                   key={title}
                   exact={exact}
-                  styleName="link"
+                  styleName={cx('link', { 'active': activeRoute === link })}
                   to={link}
-                  activeClassName={styles.active}
+                  // activeClassName={styles.active}
                 >
                   {title}
                 </NavLink>


### PR DESCRIPTION
#526 
Я там чуток сговнокодил с `componentDidMount` где тригерится нажатие, другого способа не придумал. `activeClassName` срабатывает только когда `window.location.pathname` === `to`. Там же на exchange стоит редирект на текущую пару e.g. `/btc-eth` и стиль не применяется. Если перезагрузить страницу с `/eth-btc`, то в редуксе не будет события где роутер меняет локацию на `/exchange` и поэтому нельзя красиво всё оформить через прослушку `@@router/LOCATION_CHANGE`