### PR TITLE
Локализация

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -44,6 +44,7 @@
     "transform-es2015-destructuring",
     "transform-object-rest-spread",
     "transform-runtime",
-    "transform-decorators-legacy"
+    "transform-decorators-legacy",
+    "transform-class-properties"
   ]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,6 +12,7 @@ plugins:
   - react
   - import
   - babel
+  - reactintl
 
 env:
   browser: true
@@ -126,3 +127,6 @@ rules:
   jsx-a11y/label-has-for: 0
   jsx-a11y/anchor-is-valid: 0
   jsx-a11y/interactive-supports-focus: 0
+
+  reactintl/default-message: 2
+  reactintl/contains-hardcoded-copy: 2

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./bin/server",
   "scripts": {
     "test": "cypress open",
-    "eslint": "eslint  --fix --cache ./shared --ext js",
+    "eslint": "eslint --fix --cache ./shared --ext js",
+    "validate": "eslint --cache ./shared --ext js",
     "start": "npm run dev",
     "dev": "npm run dev:testnet",
     "prod": "npm run dev:mainnet",
@@ -18,7 +19,8 @@
     "build:mainnet": "npm run clean:mainnet && cross-env DEBUG=app:* CONFIG=mainnet.prod node ./bin/compile",
     "test:unit": "mocha --require babel-core/register --require ./test/helpers.js --require ./test/dom.js --require ignore-styles 'src/**/*.spec.js'",
     "test:snapshot": "jest --config ./test/jest.config.json",
-    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls"
+    "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
+    "messages:extract": "babel-node tools/run messages"
   },
   "keywords": [],
   "author": "@nikdementev",
@@ -36,6 +38,7 @@
     "babel-loader": "^7.1.4",
     "babel-minify": "^0.4.3",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-react-intl": "^2.4.0",
     "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
@@ -71,6 +74,7 @@
     "eslint-plugin-import": "^2.12.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.8.2",
+    "eslint-plugin-reactintl": "^0.1.3",
     "exports-loader": "^0.7.0",
     "express": "^4.16.3",
     "extract-text-webpack-plugin": "^3.0.2",
@@ -124,6 +128,7 @@
     "react-dom": "^16.3.2",
     "react-gtm-module": "^2.0.2",
     "react-input-mask": "^2.0.1",
+    "react-intl": "^2.7.1",
     "react-paginate": "^5.2.3",
     "react-redux": "^5.0.7",
     "react-router": "^4.2.0",

--- a/shared/components/Header/Header.js
+++ b/shared/components/Header/Header.js
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types'
 import { connect } from 'redaction'
 import { withRouter } from 'react-router-dom'
 import { isMobile } from 'react-device-detect'
+import links from 'helpers/links'
+import { defineMessages, injectIntl } from 'react-intl'
+
 
 import CSSModules from 'react-css-modules'
 import styles from './Header.scss'
@@ -16,9 +19,40 @@ import Logo from 'components/Logo/Logo'
 import WidthContainer from 'components/layout/WidthContainer/WidthContainer'
 
 
+let lastScrollTop = 0
+
+const messages = defineMessages({
+  wallet: {
+    id: 'menu.wallet',
+    description: 'Menu item "Wallet"',
+    defaultMessage: 'Wallet',
+  },
+  exchange: {
+    id: 'menu.exchange',
+    description: 'Menu item "Exchange"',
+    defaultMessage: 'Exchange',
+  },
+  history: {
+    id: 'menu.history',
+    description: 'Menu item "History"',
+    defaultMessage: 'History',
+  },
+  affiliate: {
+    id: 'menu.affiliate',
+    description: 'Menu item "Affiliate"',
+    defaultMessage: 'Affiliate',
+  },
+  listing: {
+    id: 'menu.listing',
+    description: 'Menu item "Listing"',
+    defaultMessage: 'Listing',
+  },
+})
+
+
+@injectIntl
 @withRouter
-@connect(({ menu: { items: menuItems, isDisplayingTable } }) => ({
-  menuItems,
+@connect(({ menu: { isDisplayingTable } }) => ({
   isDisplayingTable,
 }))
 @CSSModules(styles, { allowMultiple: true })
@@ -35,11 +69,39 @@ export default class Header extends Component {
     isDisplayingTable: false,
   }
 
-  constructor() {
-    super()
+  constructor(props) {
+    super(props)
 
     this.state = {
       sticky: false,
+      menuItems: [
+        {
+          title: props.intl.formatMessage(messages.wallet),
+          link: links.home,
+          exact: true,
+          icon: 'wallet',
+        },
+        {
+          title: props.intl.formatMessage(messages.exchange),
+          link: links.exchange,
+          icon: 'exchange-alt',
+        },
+        {
+          title: props.intl.formatMessage(messages.history),
+          link: links.history,
+          icon: 'history',
+        },
+        {
+          title: props.intl.formatMessage(messages.affiliate),
+          link: links.affiliate,
+          isMobile: false,
+        },
+        {
+          title: props.intl.formatMessage(messages.listing),
+          link: links.listing,
+          isMobile: false,
+        },
+      ],
     }
 
     this.lastScrollTop = 0
@@ -65,8 +127,8 @@ export default class Header extends Component {
   }
 
   render() {
-    const { menuItems, isDisplayingTable } = this.props
-    const { sticky } = this.state
+    const { isDisplayingTable } = this.props
+    const { sticky, menuItems } = this.state
 
     if (isMobile) {
       return <NavMobile menu={menuItems} />

--- a/shared/containers/IntlProviderContainer.js
+++ b/shared/containers/IntlProviderContainer.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react'
+import { IntlProvider, addLocaleData } from 'react-intl'
+import localeEn from 'react-intl/locale-data/en'
+import localeRu from 'react-intl/locale-data/ru'
+
+
+addLocaleData([...localeEn, ...localeRu])
+
+import myEn from 'localisation/en.json'
+import myRu from 'localisation/ru.json'
+
+
+import { reduceMessages, currentLocale, defaultLocale } from 'helpers/locale'
+
+
+const translations = {
+  en: reduceMessages(myEn),
+  ru: reduceMessages(myRu),
+}
+
+export default class IntlProviderContainer extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentLocale: currentLocale(),
+      defaultLocale: defaultLocale(),
+    }
+  }
+
+  render() {
+    const { currentLocale, defaultLocale } = this.state
+    const messages = translations[currentLocale]
+    return (
+      <IntlProvider locale={currentLocale} defaultLocale={defaultLocale} messages={messages}>
+        {this.props.children}
+      </IntlProvider>
+    )
+  }
+}

--- a/shared/containers/Root/Root.js
+++ b/shared/containers/Root/Root.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types'
 import { Provider } from 'react-redux'
 import { ConnectedRouter } from 'react-router-redux'
 
+
 import App from 'containers/App/App'
+import IntlProviderContainer from 'containers/IntlProviderContainer'
 
 
 export default class Root extends React.PureComponent {
@@ -19,9 +21,11 @@ export default class Root extends React.PureComponent {
     return (
       <Provider store={store}>
         <ConnectedRouter history={history}>
-          <App>
-            {routes}
-          </App>
+          <IntlProviderContainer>
+            <App>
+              {routes}
+            </App>
+          </IntlProviderContainer>
         </ConnectedRouter>
       </Provider>
     )

--- a/shared/helpers/locale.js
+++ b/shared/helpers/locale.js
@@ -1,0 +1,9 @@
+export const reduceMessages = result =>
+  result.reduce(
+    (acc, msg) => ({ ...acc, [msg.id]: msg.message || msg.defaultMessage }),
+    {}
+  )
+
+export const currentLocale = () => 'en'
+
+export const defaultLocale = () => 'en'

--- a/shared/localisation/_default.json
+++ b/shared/localisation/_default.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "menu.affiliate",
+    "message": "Affiliate",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.exchange",
+    "message": "Exchange",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.history",
+    "message": "History",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.listing",
+    "message": "Listing",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.wallet",
+    "message": "Wallet",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "LtcToEth.orderCreatorIsOffline",
+    "message": "The order creator is offline. Waiting for him..",
+    "files": [
+      "shared/pages/Swap/LtcToEth.js"
+    ]
+  }
+]

--- a/shared/localisation/en.json
+++ b/shared/localisation/en.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "menu.affiliate",
+    "message": "Affiliate",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.exchange",
+    "message": "Exchange",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.history",
+    "message": "History",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.listing",
+    "message": "Listing",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.wallet",
+    "message": "Wallet",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "LtcToEth.orderCreatorIsOffline",
+    "message": "The order creator is offline. Waiting for him..",
+    "files": [
+      "shared/pages/Swap/LtcToEth.js"
+    ]
+  }
+]

--- a/shared/localisation/ru.json
+++ b/shared/localisation/ru.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "menu.affiliate",
+    "message": "Филиал",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.exchange",
+    "message": "Обмен",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.history",
+    "message": "История",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.listing",
+    "message": "Листинг",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "menu.wallet",
+    "message": "Кошелек",
+    "files": [
+      "shared/components/Header/Header.js"
+    ]
+  },
+  {
+    "id": "LtcToEth.orderCreatorIsOffline",
+    "message": "Автор ушел",
+    "files": [
+      "shared/pages/Swap/LtcToEth.js"
+    ]
+  }
+]

--- a/shared/pages/Swap/LtcToEth.js
+++ b/shared/pages/Swap/LtcToEth.js
@@ -9,6 +9,7 @@ import actions from 'redux/actions'
 import Timer from './Timer/Timer'
 import InlineLoader from 'components/loaders/InlineLoader/InlineLoader'
 import { TimerButton, Button } from 'components/controls'
+import { FormattedMessage } from 'react-intl'
 
 
 export default class LtcToEth extends Component {
@@ -99,7 +100,9 @@ export default class LtcToEth extends Component {
               <h3>This order doesn&apos;t have a buyer</h3>
             ) : (
               <Fragment>
-                <h3>The order creator is offline. Waiting for him..</h3>
+                <FormattedMessage id="LtcToEth.orderCreatorIsOffline" defaultMessage="The order creator is offline. Waiting for him..">
+                  {message => <h3>{message}</h3>}
+                </FormattedMessage>
                 <InlineLoader />
               </Fragment>
             )

--- a/shared/redux/reducers/menu.js
+++ b/shared/redux/reducers/menu.js
@@ -1,35 +1,4 @@
-import links from 'helpers/links'
-
-
 export const initialState = {
-  items: [
-    {
-      title: 'Wallet',
-      link: links.home,
-      exact: true,
-      icon: 'wallet',
-    },
-    {
-      title: 'Exchange',
-      link: links.exchange,
-      icon: 'exchange-alt',
-    },
-    {
-      title: 'History',
-      link: links.history,
-      icon: 'history',
-    },
-    {
-      title: 'Affiliate',
-      link: links.affiliate,
-      isMobile: false,
-    },
-    {
-      title: 'Listing',
-      link: links.listing,
-      isMobile: false,
-    },
-  ],
   isDisplayingTable: false,
 }
 

--- a/tools/libs/fs.js
+++ b/tools/libs/fs.js
@@ -1,0 +1,102 @@
+import fs from 'fs'
+import path from 'path'
+import globPkg from 'glob'
+import mkdirp from 'mkdirp'
+import rimraf from 'rimraf'
+
+export const readFile = file =>
+  new Promise((resolve, reject) => {
+    fs.readFile(file, 'utf8', (err, data) => (err ? reject(err) : resolve(data)))
+  })
+
+export const writeFile = (file, contents) =>
+  new Promise((resolve, reject) => {
+    fs.writeFile(file, contents, 'utf8', err => (err ? reject(err) : resolve()))
+  })
+
+export const renameFile = (source, target) =>
+  new Promise((resolve, reject) => {
+    fs.rename(source, target, err => (err ? reject(err) : resolve()))
+  })
+
+export const copyFile = (source, target) =>
+  new Promise((resolve, reject) => {
+    let cbCalled = false
+    function done(err) {
+      if (!cbCalled) {
+        cbCalled = true
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      }
+    }
+
+    const rd = fs.createReadStream(source)
+    rd.on('error', err => done(err))
+    const wr = fs.createWriteStream(target)
+    wr.on('error', err => done(err))
+    wr.on('close', err => done(err))
+    rd.pipe(wr)
+  })
+
+export const readDir = (pattern, options) =>
+  new Promise((resolve, reject) => globPkg(pattern, options, (err, result) => (err ? reject(err) : resolve(result))))
+
+export const makeDir = name =>
+  new Promise((resolve, reject) => {
+    mkdirp(name, err => (err ? reject(err) : resolve()))
+  })
+
+export const glob = (pattern, ignore) =>
+  new Promise((resolve, reject) => {
+    globPkg(pattern, { ignore }, (err, val) => (err ? reject(err) : resolve(val)))
+  })
+
+export const moveDir = async (source, target) => {
+  const dirs = await readDir('**/*.*', {
+    cwd: source,
+    nosort: true,
+    dot: true,
+  })
+  await Promise.all(
+    dirs.map(async dir => {
+      const from = path.resolve(source, dir)
+      const to = path.resolve(target, dir)
+      await makeDir(path.dirname(to))
+      await renameFile(from, to)
+    }),
+  )
+}
+
+export const copyDir = async (source, target) => {
+  const dirs = await readDir('**/*.*', {
+    cwd: source,
+    nosort: true,
+    dot: true,
+  })
+  await Promise.all(
+    dirs.map(async dir => {
+      const from = path.resolve(source, dir)
+      const to = path.resolve(target, dir)
+      await makeDir(path.dirname(to))
+      await copyFile(from, to)
+    }),
+  )
+}
+
+export const cleanDir = (pattern, options) =>
+  new Promise((resolve, reject) => rimraf(pattern, { glob: options }, (err, result) => (err ? reject(err) : resolve(result))))
+
+export default {
+  readFile,
+  writeFile,
+  renameFile,
+  copyFile,
+  readDir,
+  makeDir,
+  copyDir,
+  moveDir,
+  cleanDir,
+}

--- a/tools/messages.js
+++ b/tools/messages.js
@@ -1,0 +1,165 @@
+import {
+  transform
+} from 'babel-core'
+import {
+  readFile,
+  writeFile,
+  glob
+} from './libs/fs'
+
+const locales = {
+  en: 'English',
+  ru: 'Russian'
+}
+
+const GLOB_PATTERN = 'shared/**/*.{js,ts,tsx}'
+const GLOB_IGNORE = []
+const fileToMessages = {}
+let messages = {}
+
+const posixPath = fileName => fileName.replace(/\\/g, '/')
+
+async function writeMessages(fileName, msgs) {
+  return await writeFile(fileName, `${JSON.stringify(msgs, null, 2)}\n`)
+}
+
+/**
+ * merge messages to source files
+ **/
+async function mergeToJson(locale, toBuild) {
+  const fileName = `shared/localisation/${locale}.json`
+  const oldMessages = {}
+  try {
+    const localisationFile = await readFile(fileName)
+    let oldJson
+    try {
+      oldJson = JSON.parse(localisationFile)
+    } catch (err) {
+      throw new Error(`Error during parsing messages JSON in file ${fileName}`)
+    }
+
+    oldJson.forEach(message => {
+      oldMessages[message.id] = message
+      delete oldMessages[message.id].files
+    })
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+
+  Object.keys(messages).forEach(id => {
+    const newMessage = messages[id]
+    oldMessages[id] = oldMessages[id] || { id }
+    const msg = oldMessages[id]
+    msg.description = newMessage.description || msg.description
+    msg.defaultMessage = newMessage.defaultMessage || msg.defaultMessage
+    msg.message = msg.message || msg.defaultMessage
+    msg.files = newMessage.files
+    delete msg.description
+    delete msg.defaultMessage
+  })
+
+  const result = Object.keys(oldMessages).map(key => oldMessages[key]).filter(msg => msg.files || msg.message)
+
+  await writeMessages(fileName, result)
+
+  console.info(`Messages updated in: ${fileName}`)
+
+  if (toBuild && locale !== '_default') {
+    const buildFileName = `build/messages/${locale}.json`
+    try {
+      await writeMessages(buildFileName, result)
+      console.info(`Build messages updated: ${buildFileName}`)
+    } catch (err) {
+      console.error(`Failed to update: ${buildFileName}`)
+    }
+  }
+}
+
+/**
+ * Call everytime before updating file!
+ **/
+function mergeMessages() {
+  messages = {}
+  Object.keys(fileToMessages).forEach(fileName => {
+    fileToMessages[fileName].forEach(newMsg => {
+      if (messages[newMsg.id]) {
+        if (messages[newMsg.id].defaultMessage !== newMsg.defaultMessage) {
+          throw new Error(`Different message default messages for message id "${
+            newMsg.id
+          }":
+          ${messages[newMsg.id].defaultMessage} -- ${messages[newMsg.id].files}
+          ${newMsg.defaultMessage} -- ${fileName}`)
+        }
+        if (messages[newMsg.id].description && newMsg.description) {
+          throw new Error(`Should be only one description for message id "${
+            newMsg.id
+          }":
+          ${messages[newMsg.id].description} -- ${messages[newMsg.id].files}
+          ${newMsg.description} -- ${fileName}`)
+        }
+      }
+      const message = messages[newMsg.id] || {}
+      messages[newMsg.id] = {
+        description: newMsg.description || message.description,
+        defaultMessage: newMsg.defaultMessage || message.defaultMessage,
+        message: newMsg.message || message.message || '',
+        files: message.files ? [...message.files, fileName].sort() : [fileName]
+      }
+    })
+  })
+}
+
+/**
+ * Update messages
+ */
+async function updateMessages(toBuild) {
+  mergeMessages()
+  await Promise.all(
+    ['_default', ...Object.keys(locales)].map(locale => mergeToJson(locale, toBuild))
+  )
+}
+
+/**
+ * Extract react-intl messages.
+ */
+async function extractMessages() {
+  const compare = (a, b) => {
+    if (a === b) {
+      return 0
+    }
+
+    return a < b ? -1 : 1
+  }
+
+  const compareMessages = (a, b) => compare(a.id, b.id)
+
+  const extractFromSingleFile = async fileName => {
+    try {
+      const source = await readFile(fileName)
+      const posixName = posixPath(fileName)
+      const result = transform(source, {
+          babelrc: true,
+          plugins: [
+            'react-intl',
+          ],
+          filename: fileName
+        })
+        .metadata['react-intl']
+      if (result.messages && result.messages.length) {
+        fileToMessages[posixName] = result.messages.sort(compareMessages)
+      } else {
+        delete fileToMessages[posixName]
+      }
+    } catch (err) {
+      console.error(`extractMessages:\nFile: ${fileName}\n`, err.codeFrame || err)
+    }
+  }
+
+  const files = await glob(GLOB_PATTERN, GLOB_IGNORE)
+  await Promise.all(files.map(extractFromSingleFile))
+  await updateMessages()
+}
+
+export default extractMessages

--- a/tools/run.js
+++ b/tools/run.js
@@ -1,0 +1,37 @@
+export function format(time) {
+  return time.toTimeString().replace(/.*(\d{2}:\d{2}:\d{2}).*/, "$1")
+}
+
+function run(fn, options) {
+  const task = typeof fn.default === 'undefined' ? fn : fn.default
+  const start = new Date()
+  console.info(
+    `[${format(start)}] Starting '${task.name}${
+      options ? ` (${options})` : ''
+    }'...`
+  )
+  return task(options).then(resolution => {
+    const end = new Date()
+    const time = end.getTime() - start.getTime()
+    console.info(
+      `[${format(end)}] Finished '${task.name}${
+        options ? ` (${options})` : ''
+      }' after ${time} ms`
+    )
+    return resolution
+  })
+}
+
+if (require.main === module && process.argv.length > 2) {
+  // eslint-disable-next-line no-underscore-dangle
+  delete require.cache[__filename]
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  const module = require(`./${process.argv[2]}.js`).default
+
+  run(module).catch(err => {
+    console.error(err.stack)
+    process.exit(1)
+  })
+}
+
+export default run


### PR DESCRIPTION
* В `eslint` добавлено правило `reactintl/contains-hardcoded-copy` для того, чтобы все захардкоженные строки были представлены в виде `defineMessages` или `<FormattedMessage />` **(кстати, проверка вашим eslint вашего исходного кода выдает кучу ошибок)**
* После добавления/изменения ресурсов необходимо выполнить команду `npm run messages:extract` для формирования файла ресурсов (будут располагаться в `shared/localisation/`, на данный момент это три файла: `_default`, `en` и `ru`). Уже существующие переводы будут дополнены новыми ресурсами (удаленные переводы в файле останутся при этом). **Но это лучше тщательно проверить**
* На данный момент дефолтная локаль всегда `en`, после заполнения файла русских ресурсов это изменю
* Данные меню были вынесены из редюсера (для удобства перевода) в сам компонент `Header`
* Сейчас очень много захардкоженных строк, которые нужно превратить в ресурсы (WIP), если кто-то может помочь с этим - будет отлично.
