### PR TITLE
eos auth refactoring

### DIFF
--- a/shared/components/modals/EosRegisterModal/EosRegisterModal.js
+++ b/shared/components/modals/EosRegisterModal/EosRegisterModal.js
@@ -11,7 +11,7 @@ import { constants } from 'helpers'
 
 import cssModules from 'react-css-modules'
 import styles from './EosRegisterModal.scss'
-import Tooltip from 'components/ui/Tooltip/Tooltip' 
+import Tooltip from 'components/ui/Tooltip/Tooltip'
 
 
 @cssModules(styles)
@@ -52,7 +52,7 @@ export default class EosRegisterModal extends React.Component {
       <Modal name={name} title="EOS Login">
         <FieldLabel inRow>Account name <Tooltip text="Enter your EOS account name "/></FieldLabel>
         <Input valueLink={linked.accountName} />
-        <FieldLabel inRow>Private key <Tooltip text="Enter your EOS secret key"/></FieldLabel>
+        <FieldLabel inRow>Active private key<Tooltip text="Enter private key for active permission"/></FieldLabel>
         <Input valueLink={linked.privateKey} />
         { error && (
           <div styleName="error">Sorry, error occured during activation</div>

--- a/shared/components/modals/WithdrawModal/WithdrawModal.js
+++ b/shared/components/modals/WithdrawModal/WithdrawModal.js
@@ -72,7 +72,7 @@ export default class WithdrawModal extends React.Component {
     const isDisabled = !address || !amount
 
     if (isSubmitted) {
-      linked.amount.check((value) => value > minAmount[data.currency], `Amount must be greater than ${minAmount[data.currency]} `)
+      linked.amount.check((value) => value > minAmount[data.currency], `Amount must be greater than ${minAmount[data.currency.toLowerCase()]} `)
       linked.amount.check((value) => value < balance, `Amount must be bigger your balance`)
     }
 

--- a/shared/helpers/constants/localStorage.js
+++ b/shared/helpers/constants/localStorage.js
@@ -5,4 +5,6 @@ export default {
   hiddenCoinsList: 'hiddenCoinsList',
   testnetSkip: 'testnetSkip',
   storageRevision: '_revision',
+  eosActivationPayment: `${process.env.ENTRY}:eos:activationPayment`,
+  eosAccountActivated: `${process.env.ENTRY}:eos:activationFlag`
 }

--- a/shared/helpers/eos.js
+++ b/shared/helpers/eos.js
@@ -11,12 +11,12 @@ const keyProvider = (telos = false) => {
 
   return ({ transaction, pubkeys }) => {
     const { user } = getState()
-    const { privateKeys, publicKeys } = user[userDataKey]
+    const { activePrivateKey, activePublicKey } = user[userDataKey]
 
     if (pubkeys || telos) {
-      return [privateKeys.active]
+      return [activePrivateKey]
     } else {
-      return [publicKeys.active]
+      return [activePublicKey]
     }
   }
 }

--- a/shared/pages/Wallet/Row/Row.js
+++ b/shared/pages/Wallet/Row/Row.js
@@ -133,6 +133,7 @@ export default class Row extends Component {
   render() {
     const { isBalanceFetching, tradeAllowed, isAddressCopied } = this.state
     const { currency, balance, isBalanceFetched, address, contractAddress, fullName, unconfirmedBalance } = this.props
+    const eosActivationAvailable = localStorage.getItem(constants.localStorage.eosAccountActivated) === "true" ? false : true
 
     return (
       <tr onClick={this.handleShowOptions} styleName={this.state.showMobileButtons ? 'showButtons' : ''}>
@@ -205,29 +206,24 @@ export default class Row extends Component {
                   )
                 }
 
-
-                <div>
-                  {
-                    currency === 'EOS' && address === '' && <button styleName="button" onClick={this.handleEosRegister} data-tip data-for="lE">Login</button>
-                  }
-                  <ReactTooltip id="lE" type="light" effect="solid">
-                    <span>login if you have EOS account yet</span>
-                  </ReactTooltip>
-                  {
-                    currency === 'EOS' && address === '' && <button styleName="button" onClick={this.handleEosBuyAccount} data-tip data-for="bE">Buy account</button>
-                  }
-                  <ReactTooltip id="bE" type="light" effect="solid">
-                    <span>Buy EOS account if you have not it</span>
-                  </ReactTooltip>
-                </div>
-                <div>
-                  {
-                    currency === 'TLOS' && address === '' && <button styleName="button" onClick={this.handleTelosRegister} data-tip data-for="lT">Login</button>
-                  }
-                  <ReactTooltip id="lT" type="light" effect="solid">
-                    <span>login if you have TLOS account yet</span>
-                  </ReactTooltip>
-                </div>
+                {
+                  currency === 'EOS' && eosActivationAvailable && <button styleName="button" onClick={this.handleEosBuyAccount} data-tip data-for="bE">Activate</button>
+                }
+                <ReactTooltip id="bE" type="light" effect="solid">
+                  <span>Buy this account</span>
+                </ReactTooltip>
+                {
+                  currency === 'EOS' && <button styleName="button" onClick={this.handleEosRegister} data-tip data-for="lE">Use another</button>
+                }
+                <ReactTooltip id="lE" type="light" effect="solid">
+                  <span>Login with your existing eos account</span>
+                </ReactTooltip>
+                {
+                  currency === 'TLOS' && address === '' && <button styleName="button" onClick={this.handleTelosRegister} data-tip data-for="lT">Login</button>
+                }
+                <ReactTooltip id="lT" type="light" effect="solid">
+                  <span>login if you have TLOS account yet</span>
+                </ReactTooltip>
                 { isAddressCopied && <p styleName="copied" >Address copied to clipboard</p> }
               </td>
             </CopyToClipboard>

--- a/shared/redux/actions/tlos.js
+++ b/shared/redux/actions/tlos.js
@@ -30,12 +30,7 @@ const register = async (accountName, activePrivateKey) => {
 
   const keys = {
     activePrivateKey: activePrivateKey,
-    privateKeys: {
-      active: activePrivateKey
-    },
-    publicKeys: {
-      active: givenPublicKey
-    }
+    activePublicKey: givenPublicKey,
   }
 
   reducers.user.setAuthData({ name: 'telosData', data: { ...keys, address: accountName } })
@@ -46,16 +41,9 @@ const login = async (accountName, activePrivateKey) => {
 
   const keys = {
     activePrivateKey,
-    privateKeys: {
-      active: activePrivateKey
-    },
-    publicKeys: {
-      active: activePublicKey
-    }
+    activePublicKey
   }
 
-  console.log('keys', keys)
-  console.log('accountName', accountName)
   reducers.user.setAuthData({ name: 'telosData', data: { ...keys, address: accountName } })
 }
 

--- a/shared/redux/actions/user.js
+++ b/shared/redux/actions/user.js
@@ -26,12 +26,16 @@ const sign = async () => {
     })
   // await actions.nimiq.login(_ethPrivateKey)
 
-  const eosMasterPrivateKey = localStorage.getItem(constants.privateKeyNames.eos)
+  const eosActivePrivateKey = localStorage.getItem(constants.privateKeyNames.eos)
   const eosAccount = localStorage.getItem(constants.privateKeyNames.eosAccount)
-  if (eosMasterPrivateKey && eosAccount) {
-    await actions.eos.login(eosAccount, eosMasterPrivateKey)
-    await actions.eos.getBalance()
+
+  if (eosActivePrivateKey && eosAccount) {
+    await actions.eos.login(eosAccount, eosActivePrivateKey)
+  } else {
+    await actions.eos.loginWithNewAccount()
   }
+
+  await actions.eos.getBalance()
 
   const telosActivePrivateKey = localStorage.getItem(constants.privateKeyNames.telos)
   const telosAccount = localStorage.getItem(constants.privateKeyNames.telosAccount)


### PR DESCRIPTION
* save activation info in local storage instead of component state
* show account name on first login instead after activation
* ask private key for active permission instead of master private key