### PR TITLE
Fix calculate final balance width unconfirmed balance;

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ cd swap.react
 npm i
 ```
 
-3) For dev mode `npm run start`, for prod `npm run build`
+3) Do `git submodule update` in swap.react directory
+
+4) For dev mode `npm run start`, for prod `npm run build`
 
 ```
 npm run start

--- a/shared/components/modals/OfferModal/AddOffer/AddOffer.js
+++ b/shared/components/modals/OfferModal/AddOffer/AddOffer.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react'
 
 import { connect } from 'redaction'
 import actions from 'redux/actions'
-import reducers from 'redux/core/reducers'
 
 import Link from 'sw-valuelink'
 import config from 'app-config'


### PR DESCRIPTION
Fix issue #711
Учитывает отрицательный неподтвержденный баланс, чтобы не дать потратить, что уже потрачено.

![screenshot_20181023_161306](https://user-images.githubusercontent.com/43396375/47339621-2022c200-d6df-11e8-8b9f-bb28edbfc9e8.png)

Не учитывается положительный неподтвержденный баланс, так как фактически его пока нет.

![screenshot_20181023_161324](https://user-images.githubusercontent.com/43396375/47339628-27e26680-d6df-11e8-81af-53eda8bb333c.png)

Но! Если в неподтверженном балансе будет положительная часть больше отрицательной, то неподтвержденный баланс не будет учитываться, однако можно попытаться потратить отрицательный неподтвержденный баланс, которого фактически уже нет, что приведет к изначальной ошибке.

Для решения этой проблемы нужно разработать метод getUnconfirmedBalance в actions/[coin].js для получения неподтвержденного баланса объектом вроде:
unconfirmedBalance = {
plus: 24.3402
minus: -0.23003
}
Метод getUnconfirmedBalance будет перебирать все неподтвержденные транзакции и суммировать  отрицательные и положительные балансы соответственно в "plus" и "minus"