### PR TITLE
Fix calculate final balance with unconfirmed balance;

### DIFF
--- a/shared/components/modals/OfferModal/AddOffer/AddOffer.js
+++ b/shared/components/modals/OfferModal/AddOffer/AddOffer.js
@@ -32,9 +32,15 @@ const minAmount = {
 }
 
 
-@connect(({ currencies }) => ({
-  currencies: currencies.items,
-}))
+@connect(
+  ({
+    currencies,
+    user: { ethData, btcData, bchData, tokensData, eosData, telosData, nimData, usdtData, ltcData },
+  }) => ({
+    currencies: currencies.items,
+    items: [ ethData, btcData, eosData, telosData, bchData, ltcData, usdtData /* nimData */ ],
+  })
+)
 @cssModules(styles, { allowMultiple: true })
 export default class AddOffer extends Component {
   constructor({ initialData }) {
@@ -64,11 +70,20 @@ export default class AddOffer extends Component {
   }
 
   checkBalance = async (sellCurrency) => {
-    const balance = await actions[sellCurrency].getBalance(sellCurrency)
+    const { items } = this.props
+
+    const currency = items
+      .filter(item => item.currency === sellCurrency.toUpperCase())[0]
+
+    const balance = currency.balance
+    const unconfirmedBalance = currency.unconfirmedBalance;
+    const finalBalance = unconfirmedBalance !== undefined && unconfirmedBalance < 0
+                         ? Number(balance) + Number(unconfirmedBalance)
+                         : balance
     const ethBalance = await actions.eth.getBalance()
 
     this.setState({
-      balance,
+      finalBalance,
       ethBalance,
     })
   }

--- a/shared/pages/Home/Orders/Orders.js
+++ b/shared/pages/Home/Orders/Orders.js
@@ -60,10 +60,14 @@ export default class Orders extends Component {
     }
   }
 
-  createOffer = () => {
+  createOffer = async () => {
+    const { buyCurrency, sellCurrency } = this.props
+
+    await actions[sellCurrency].getBalance(sellCurrency)
+
     actions.modals.open(constants.modals.Offer, {
-      buyCurrency: this.props.buyCurrency,
-      sellCurrency: this.props.sellCurrency,
+      buyCurrency,
+      sellCurrency,
     })
     actions.analytics.dataEvent('orderbook-click-createoffer-button')
   }


### PR DESCRIPTION
Fix issue #711
Учитывает отрицательный неподтвержденный баланс, чтобы не дать потратить, что уже потрачено.

![screenshot_20181023_161306](https://user-images.githubusercontent.com/43396375/47356379-39d7ff80-d707-11e8-8ebe-f7c29ac47f58.png)

Не учитывается положительный неподтвержденный баланс, так как фактически его пока нет.

![screenshot_20181023_161324](https://user-images.githubusercontent.com/43396375/47356384-40ff0d80-d707-11e8-8a0c-75ffe4f62a1c.png)

Но! Если в неподтверженном балансе будет положительная часть больше отрицательной, то неподтвержденный баланс не будет учитываться, однако можно попытаться потратить отрицательный неподтвержденный баланс, которого фактически уже нет, что приведет к изначальной ошибке.

Для решения этой проблемы нужно разработать метод getUnconfirmedBalance в actions/[coin].js для получения неподтвержденного баланса объектом вроде:
unconfirmedBalance = {
plus: 24.3402
minus: -0.23003
}
Метод getUnconfirmedBalance будет перебирать все неподтвержденные транзакции и суммировать отрицательные и положительные балансы соответственно в "plus" и "minus"