### PR TITLE
currency icon with title wrap fix + zorder

### DIFF
--- a/shared/components/ui/CurrencySelect/Option/Option.js
+++ b/shared/components/ui/CurrencySelect/Option/Option.js
@@ -7,7 +7,7 @@ import CurrencyIcon from 'components/ui/CurrencyIcon/CurrencyIcon'
 
 
 const Option = ({ icon, title }) => (
-  <Fragment>
+  <Fragment styleName="optionrow">
     <CurrencyIcon styleName="icon" name={icon} />
     {title}
   </Fragment>

--- a/shared/components/ui/CurrencySelect/Option/Option.scss
+++ b/shared/components/ui/CurrencySelect/Option/Option.scss
@@ -1,3 +1,6 @@
+.optionrow {
+  white-space: nowrap;
+}
 .icon {
   margin-right: 14px;
   font-size: 20px;

--- a/shared/components/ui/DropDown/DropDown.scss
+++ b/shared/components/ui/DropDown/DropDown.scss
@@ -31,7 +31,6 @@
   margin-top: -6px;
   position: absolute;
   top: 50%;
-  z-index: 9999;
   right: 20px;
 }
 


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [ x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/Contribution) guide
- [ -] branch rebased on `develop`
- [ x] styleguide check `npx eslint shared/**/*.js`
- [ x] good naming
- [ x] keep simple
- [ o] video or screenshot attached
- [ ?] testing instruction attached
- [ x] check your PR once again


### Description

<!-- Include issue number and motivation for these code changes -->

Фикс "жидкого" бага в выподающем списке
 - исправлен перенос "иконка+пояснение" в выподающем списке
 - исправлен уровень z-order (набегание нижних элементов в DOM в дочернии элементов выше)

было 
![image](https://user-images.githubusercontent.com/1880211/48585984-77632d80-e93f-11e8-9204-07252a5e91a6.png)
1. Выбранный параметр выпадающего списка (иконка+текст)  "убегал"
2. В списке вариантов аналогично (иконка+текст) "убегали"
3. "метка" развернуть список нижнего поля в доме была выше "всплывающего" окна выбора из списка выше (по DOM-у)
стало
![image](https://user-images.githubusercontent.com/1880211/48586076-dcb71e80-e93f-11e8-835c-cd58a90d23a7.png)



### Video or screenshot

<!-- Paste video or screenshots -->




### What and how to test

<!-- What reviewer should do? -->

P.S.
 Затронуты только стили => На основной функционал не влияет




