### PR TITLE
 #1017: swap request from anonymous is untrusted  - verify and show participant reputation

### DIFF
--- a/config/mainnet/swapContract.js
+++ b/config/mainnet/swapContract.js
@@ -2,4 +2,5 @@ export default {
   erc20: '0x30f85eBCFAc9f6Dd69503955e95ab7F55Fa3fDeC',
   eth: '0x843FcaAeb0Cce5FFaf272F5F2ddFFf3603F9c2A0',
   eos: 'swaponline42',
+  reputationOracle: '0x6260B5ef52d72732674fF4BDE3B37a4222dB1785',
 }

--- a/config/testnet/swapContract.js
+++ b/config/testnet/swapContract.js
@@ -2,4 +2,5 @@ export default {
   erc20: '0x2a5c40aD16ce9dD3CEE6cB4cf934aeC312e9FF2a',
   eth: '0x4356152f044e3a1ce1a57566b2e0bee57949c1b2',
   eos: 'swaponline43',
+  reputationOracle: '0x6260B5ef52d72732674fF4BDE3B37a4222dB1785',
 }

--- a/shared/components/Header/User/UserTooltip/UserTooltip.js
+++ b/shared/components/Header/User/UserTooltip/UserTooltip.js
@@ -67,9 +67,9 @@ export default class UserTooltip extends Component {
                 <div styleName="userTooltip" >
                   <div key={peer}>
                     <div styleName="title">
-                      <FormattedMessage id="userTooltip68" defaultMessage="User with" />
+                      <FormattedMessage id="userTooltip68" defaultMessage="User(" />
                       <b>{reputation}</b>
-                      <FormattedMessage id="userTooltip72" defaultMessage="reputation wants to swap" />
+                      <FormattedMessage id="userTooltip72" defaultMessage=") wants to swap" />
                     </div>
                     <div styleName="currency">
                       <span>{buyAmount.toFixed(5)} <span styleName="coin">{buyCurrency}</span></span>

--- a/shared/containers/Core/Core.js
+++ b/shared/containers/Core/Core.js
@@ -88,7 +88,7 @@ export default class Core extends Component {
     this.setState(() => ({
       orders,
     }))
-    actions.core.updateCore(orders)
+    actions.core.updateCore()
   }
 
   createOrder = async ({ fromPeer, order, ...rest }) => {

--- a/shared/helpers/index.js
+++ b/shared/helpers/index.js
@@ -7,6 +7,7 @@ import links from './links'
 import request from './request'
 import constants from './constants'
 import localStorage from './localStorage'
+import swapsExplorer from './swapsExplorer'
 import api from './api'
 import tips from './tips'
 import * as utils from './utils'
@@ -33,6 +34,7 @@ export {
   request,
   constants,
   localStorage,
+  swapsExplorer,
   api,
   migrate,
   // Methods

--- a/shared/helpers/swapsExplorer.js
+++ b/shared/helpers/swapsExplorer.js
@@ -1,0 +1,23 @@
+import config from 'app-config'
+import web3 from './web3'
+
+
+const isValidReputationProof = (participantMetadata) => {
+  const oracleMessage = JSON.stringify({
+    address: participantMetadata.address,
+    reputation: participantMetadata.reputation,
+  })
+  const oracleMessageHash = web3.utils.soliditySha3(oracleMessage)
+  const oracleAddress = web3.eth.accounts.recover(oracleMessageHash, participantMetadata.reputationProof)
+
+  if (oracleAddress !== config.swapContract.reputationOracle) {
+    return false
+  }
+
+  return true
+}
+
+const getVerifiedReputation = (participantMetadata) =>
+  isValidReputationProof(participantMetadata) ? participantMetadata.reputation : 0
+
+export default { getVerifiedReputation }

--- a/shared/instances/newSwap.js
+++ b/shared/instances/newSwap.js
@@ -2,6 +2,7 @@
 import { eos } from 'helpers/eos'
 import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only'
 import web3 from 'helpers/web3'
+import swapsExplorer from 'helpers/swapsExplorer'
 import bitcoin from 'bitcoinjs-lib'
 import coininfo from 'coininfo'
 
@@ -38,6 +39,7 @@ const createSwapApp = () => {
       Ipfs: IPFS,
       IpfsRoom: Channel,
       storage: window.localStorage,
+      swapsExplorer,
     },
 
     services: [

--- a/shared/redux/actions/btc.js
+++ b/shared/redux/actions/btc.js
@@ -55,16 +55,6 @@ const getBalance = () => {
     }, () => Promise.reject())
 }
 
-const getReputation = () =>
-  new Promise(async (resolve) => {
-    const { user: { btcData: { address } } } = getState()
-
-    const response = await request.get(`${api.getApiServer('swapsExplorer')}/reputation/${address}`)
-    const reputation = Number.isInteger(response.reputation) ? response.reputation : 0
-    reducers.user.setReputation({ name: 'btcData', reputation })
-    resolve(reputation)
-  })
-
 const fetchBalance = (address) =>
   request.get(`${api.getApiServer('bitpay')}/addr/${address}`)
     .then(({ balance }) => balance)
@@ -179,6 +169,26 @@ const signMessage = (message, encodedPrivateKey) => {
 
   return signature.toString('base64')
 }
+
+const getReputation = () =>
+  new Promise(async (resolve) => {
+    const { user: { btcData: { address, privateKey } } } = getState()
+
+    const addressOwnerSignature = signMessage(address, privateKey)
+
+    const response = await request.post(`${api.getApiServer('swapsExplorer')}/reputation`, {
+      json: true,
+      body: {
+        address,
+        addressOwnerSignature,
+      },
+    })
+
+    const { reputation, reputationOracleSignature } = response
+
+    reducers.user.setReputation({ name: 'btcData', reputation, reputationOracleSignature })
+    resolve(reputation)
+  })
 
 export default {
   login,

--- a/shared/redux/actions/core.js
+++ b/shared/redux/actions/core.js
@@ -31,7 +31,22 @@ const removeOrder = (orderId) => {
 const sendRequest = (orderId, callback) => {
   const order = SwapApp.services.orders.getByKey(orderId)
 
-  order.sendRequest(callback)
+  const getUserCurrencyData = (currency) => {
+    switch (currency.toUpperCase()) {
+      case 'BTC':
+        return getState().user.btcData
+
+      case 'ETH':
+        return getState().user.ethData
+
+      default:
+        return {}
+    }
+  }
+
+  const { address, reputation, reputationProof } = getUserCurrencyData(order.buyCurrency)
+
+  order.sendRequest(callback, { address, reputation, reputationProof })
 }
 
 const createOrder = (data) => {

--- a/shared/redux/actions/eth.js
+++ b/shared/redux/actions/eth.js
@@ -47,13 +47,24 @@ const getBalance = () => {
 
 const getReputation = () =>
   new Promise(async (resolve) => {
-    const { user: { ethData: { address } } } = getState()
+    const { user: { ethData: { address, privateKey } } } = getState()
 
-    const response = await request.get(`${api.getApiServer('swapsExplorer')}/reputation/${address}`)
-    const reputation = Number.isInteger(response.reputation) ? response.reputation : 0
-    reducers.user.setReputation({ name: 'ethData', reputation })
+    const addressOwnerSignature = web3.eth.accounts.sign(address, privateKey)
+
+    const response = await request.post(`${api.getApiServer('swapsExplorer')}/reputation`, {
+      json: true,
+      body: {
+        address,
+        addressOwnerSignature,
+      },
+    })
+
+    const { reputation, reputationOracleSignature } = response
+
+    reducers.user.setReputation({ name: 'ethData', reputation, reputationOracleSignature })
     resolve(reputation)
   })
+
 
 const fetchBalance = (address) =>
   web3.eth.getBalance(address)

--- a/shared/redux/actions/user.js
+++ b/shared/redux/actions/user.js
@@ -76,6 +76,8 @@ const getReputation = async () => {
     .then(([btcReputation, ethReputation]) => {
       const totalReputation = Number(btcReputation) + Number(ethReputation)
       reducers.ipfs.set({ reputation: totalReputation })
+    }).catch((error) => {
+      console.error(error)
     })
 }
 

--- a/shared/redux/reducers/user.js
+++ b/shared/redux/reducers/user.js
@@ -114,7 +114,7 @@ export const setTokenApprove = (state, { name, approve }) => ({
   },
 })
 
-export const setReputation = (state, { name, reputation }) => ({
+export const setReputation = (state, { name, reputation, reputationOracleSignature }) => ({
   ...state,
   tokensData: {
     ...state.tokensData,
@@ -122,5 +122,6 @@ export const setReputation = (state, { name, reputation }) => ({
   [name]: {
     ...state[name],
     reputation: Number(reputation),
+    reputationProof: reputationOracleSignature,
   },
 })


### PR DESCRIPTION
При инициализации приложения, пользователь запрашивает значение своей репутации у сервиса, и сохраняет это значение в состоянии приложения. Когда сервис отправляет ответ, он также отправляет сигнатуру, которая является доказательством того, что пользователь получил это значение от сервиса. Также, сервис требует, чтобы пользователь отправил в запросе свою сигнатуру для того, чтобы сервис знал, что пользователь запрашивает рейтинг адреса, который ему принадлежит.
Когда пользователь отправляет запрос на выполнение свопа, он также отправляет в сообщении свой рейтинг и сигнатуру от сервиса. На стороне создателя свопа, перед отображением запроса, проверяется, действительно ли покупатель получил рейтинг от сервиса, и в противном случае значение рейтинга устанавливается равным нулю.

* Пользователь отправляет в сообщении не общий рейтинг, а свой рейтинг как покупателя соответствующей криптовалюты.