### PR TITLE
Fix component width for modal content

### DIFF
--- a/shared/components/layout/Center/Center.scss
+++ b/shared/components/layout/Center/Center.scss
@@ -39,7 +39,7 @@
 }
 
 .centringContent {
-  width: 100%;
+  max-width: 100%;
   display: inline-block;
   white-space: normal;
   vertical-align: middle;


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/Contribution) guide
- [ ] branch rebased on `develop`
- [ ] styleguide check `npm run validate`
- [ ] good naming
- [ ] keep simple
- [ ] video or screenshot attached
- [ ] testing instruction attached
- [ ] check your PR once again


### Description

Fix issue #1108 


### Video or screenshot

![screenshot_20181209_195922](https://user-images.githubusercontent.com/43396375/49695870-0be24800-fbed-11e8-8512-f232a6f9f635.png)
![screenshot_20181209_200006](https://user-images.githubusercontent.com/43396375/49695871-0c7ade80-fbed-11e8-8eb4-b6cb05ba6f06.png)

### What and how to test

1. Open addOffer modal (desktop)
2. (iphone mod) Open download key modal





