### PR TITLE
orderbook: во время реквеста на старт свапа если добавился новый ордер в ордербук почему то интерфейс перекидывет реквест на него

### DIFF
--- a/shared/components/tables/Table/Table.js
+++ b/shared/components/tables/Table/Table.js
@@ -81,9 +81,11 @@ export default class Table extends React.Component {
             )
           }
           {
-            !isLoading && !!rows.length && rows.map((row, rowIndex) => (
-              typeof rowRender === 'function' && rowRender(row, rowIndex, this.state.selectId, this.handleSelectId)
-            ))
+            !isLoading && !!rows.length && rows.map((row, rowIndex) => {
+              if (typeof rowRender === 'function') {
+                return rowRender(row, rowIndex)
+              }
+            })
           }
         </tbody>
       </table>

--- a/shared/components/tables/Table/Table.js
+++ b/shared/components/tables/Table/Table.js
@@ -83,7 +83,7 @@ export default class Table extends React.Component {
           {
             !isLoading && !!rows.length && rows.map((row, rowIndex) => {
               if (typeof rowRender === 'function') {
-                return rowRender(row, rowIndex)
+                return rowRender(row, rowIndex, this.state.selectId, this.handleSelectId)
               }
             })
           }

--- a/shared/pages/Home/Orders/Orders.js
+++ b/shared/pages/Home/Orders/Orders.js
@@ -153,9 +153,9 @@ export default class Orders extends Component {
           className={tableStyles.exchange}
           titles={titles}
           rows={sellOrders}
-          rowRender={(row, index) => (
+          rowRender={(row) => (
             <Row
-              key={index}
+              key={row.id}
               orderId={orderId}
               row={row}
             />
@@ -180,9 +180,9 @@ export default class Orders extends Component {
           className={tableStyles.exchange}
           titles={titles}
           rows={buyOrders}
-          rowRender={(row, index) => (
+          rowRender={(row) => (
             <Row
-              key={index}
+              key={row.id}
               orderId={orderId}
               row={row}
             />

--- a/shared/pages/Home/Orders/Row/Row.js
+++ b/shared/pages/Home/Orders/Row/Row.js
@@ -129,6 +129,9 @@ export default class Row extends Component {
       return <Redirect push to={`${links.swap}/${buyCurrency}-${sellCurrency}/${id}`} />
     }
 
+    console.log('row', this.props.row.exchangeRate)
+    console.log('row', this.state.isFetching)
+
     return (
       <tr style={orderId === id ? { background: 'rgba(0, 236, 0, 0.1)' } : {}}>
         <td>
@@ -199,9 +202,6 @@ export default class Row extends Component {
                           disabled={balance >= Number(buyAmount)}
                           onClick={() => this.sendRequest(id, isMy ? sellCurrency : buyCurrency)}
                           data={{ type, amount, main, total, base }}
-                          onMouseEnter={() => this.setState(() => ({ enterButton: true }))}
-                          onMouseLeave={() => this.setState(() => ({ enterButton: false }))}
-                          move={this.state.enterButton}
                         >
                           {type === PAIR_TYPES.BID ? 'SELL' : 'BUY'}
                           {' '}

--- a/shared/pages/Home/Orders/Row/Row.js
+++ b/shared/pages/Home/Orders/Row/Row.js
@@ -129,9 +129,6 @@ export default class Row extends Component {
       return <Redirect push to={`${links.swap}/${buyCurrency}-${sellCurrency}/${id}`} />
     }
 
-    console.log('row', this.props.row.exchangeRate)
-    console.log('row', this.state.isFetching)
-
     return (
       <tr style={orderId === id ? { background: 'rgba(0, 236, 0, 0.1)' } : {}}>
         <td>


### PR DESCRIPTION
## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/Contribution) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [ ] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description
https://github.com/swaponline/swap.react/issues/1074

### What and how to test
https://github.com/swaponline/swap.react/issues/1074#issue-386770263
