### PR TITLE
PR template had wrong "Contribution" link

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 <!-- You have to tick all the boxes -->
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/Contribution) guide
+- [ ] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
 - [ ] branch rebased on `develop`
 - [ ] styleguide check `npm run validate`
 - [ ] good naming


### PR DESCRIPTION
## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/Contribution) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description

Если нажать на 
![image](https://user-images.githubusercontent.com/17093843/50041947-cea70b80-006d-11e9-90c3-8d7613622534.png)
CONTRIBUTING - переход ведет на 
![image](https://user-images.githubusercontent.com/17093843/50041955-dcf52780-006d-11e9-8910-7772c03c6a31.png)
