### PR TITLE
caution с сохранением приватников пропадает после перезагрузки

### DIFF
--- a/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
+++ b/shared/components/modals/PrivateKeysModal/PrivateKeysModal.js
@@ -100,6 +100,7 @@ export default class PrivateKeysModal extends React.PureComponent {
 
   handleKeysSubmit = () => {
     localStorage.setItem(constants.localStorage.privateKeysSaved, true)
+    localStorage.setItem(constants.localStorage.wasCautionPassed, true)
     window.location.reload()
   }
 

--- a/shared/helpers/constants/localStorage.js
+++ b/shared/helpers/constants/localStorage.js
@@ -6,6 +6,7 @@ export default {
   testnetSkip: 'testnetSkip',
   storageRevision: '_revision',
   wasCautionShow: 'wasCautionShow',
+  wasCautionPassed: 'wasCautionPassed',
   hiddenCoinsList: 'hiddenCoinsList',
   privateKeysSaved: 'privateKeysSaved',
   demoMoneyReceived: 'demoMoneyReceived',

--- a/shared/pages/Wallet/Wallet.js
+++ b/shared/pages/Wallet/Wallet.js
@@ -98,21 +98,6 @@ export default class Wallet extends Component {
     }))
   }
 
-  componentDidUpdate() {
-    const { openModal } = this.state
-
-    const { currencyBalance } = this.props
-
-    const hasNonZeroCurrencyBalance = hasNonZeroBalance(currencyBalance)
-
-    if (!localStorage.getItem(constants.localStorage.wasCautionShow) && process.env.MAINNET) {
-      if (hasNonZeroCurrencyBalance) {
-        actions.modals.open(constants.modals.PrivateKeys, {})
-        localStorage.setItem(constants.localStorage.wasCautionShow, true)
-      }
-    }
-  }
-
   componentWillReceiveProps() {
     const { currencyBalance } = this.props
 
@@ -138,6 +123,22 @@ export default class Wallet extends Component {
       ...getComparableProps(nextProps),
       ...nextState,
     })
+  }
+
+  forceCautionUserSaveMoney = () => {
+    const { currencyBalance } = this.props
+
+    const hasNonZeroCurrencyBalance = hasNonZeroBalance(currencyBalance)
+
+    const doesCautionPassed = localStorage.getItem(constants.localStorage.wasCautionPassed) === 'true'
+
+    if (!doesCautionPassed && process.env.MAINNET) {
+      if (hasNonZeroCurrencyBalance) {
+        localStorage.setItem(constants.localStorage.wasCautionPassed, false)
+        actions.modals.open(constants.modals.PrivateKeys, {})
+        localStorage.setItem(constants.localStorage.wasCautionShow, true)
+      }
+    }
   }
 
   checkImportKeyHash = () => {
@@ -191,6 +192,8 @@ export default class Wallet extends Component {
         and more secure without third-parties. Decentralized exchange.`,
       },
     })
+
+    this.forceCautionUserSaveMoney()
 
     return (
       <section styleName={isMobile ? 'sectionWalletMobile' : 'sectionWallet'}>


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description

<!-- Include issue number and motivation for these code changes -->
caution с сохранением приватников пропадает после перезагрузки #1459 

1. на чистом мейннете прислать немного крипты
2. обновить, появится cautrion
3. обновить еще раз cauton исчезнет

сразу как пришла крипта сразу показать caution и не убирать его пока не пройдут квест с введением исходников



### Video or screenshot

<!-- Paste video or screenshots -->
![image](https://user-images.githubusercontent.com/24671211/52146510-01847d80-2675-11e9-80ae-9a26db852dca.png)




### What and how to test

<!-- What reviewer should do? -->
wasCautionPassed: true




