### PR TITLE
addOffer: fix any amount to actual decimals

### DIFF
--- a/shared/components/modals/OfferModal/AddOffer/AddOffer.js
+++ b/shared/components/modals/OfferModal/AddOffer/AddOffer.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 
 import { connect } from 'redaction'
 import actions from 'redux/actions'
-import helpers from 'helpers'
+import helpers, { constants } from 'helpers'
 
 import Link from 'sw-valuelink'
 import config from 'app-config'
@@ -62,7 +62,6 @@ export default class AddOffer extends Component {
       isToken: false,
       isPartial: true,
       isSending: false,
-      ethBalance: null,
       manualRate: false,
       isBuyFieldInteger: false,
       isSellFieldInteger: false,
@@ -101,7 +100,10 @@ export default class AddOffer extends Component {
     const currency = items.concat(tokenItems)
       .filter(item => item.currency === sellCurrency.toUpperCase())[0]
 
-    const { balance, unconfirmedBalance } = currency
+    let { balance, unconfirmedBalance } = currency
+
+    balance = new BigNumber(balance)
+    unconfirmedBalance = new BigNumber(unconfirmedBalance)
 
     if (helpers.ethToken.isEthToken({ name: sellCurrency })) {
       this.setState(() => ({
@@ -113,17 +115,17 @@ export default class AddOffer extends Component {
       }))
     }
 
-    const currentBalance = unconfirmedBalance !== undefined && unconfirmedBalance < 0
-      ? new BigNumber(balance).plus(unconfirmedBalance)
+    const currentBalance = unconfirmedBalance.isNaN() && unconfirmedBalance.isLessThan(0)
+      ? balance.plus(unconfirmedBalance)
       : balance
 
     if (coinsWithDynamicFee.includes(sellCurrency)) {
       minAmount[sellCurrency] = await helpers[sellCurrency].estimateFeeValue({ method: 'swap', speed: 'fast' })
-
-      const finalBalance = BigNumber(currentBalance).minus(minAmount[sellCurrency]) > 0 ? BigNumber(currentBalance).minus(minAmount[sellCurrency]) : 0
+      const balanceWithFeeValue = currentBalance.minus(minAmount[sellCurrency])
+      const finalBalance = balanceWithFeeValue.isGreaterThan(0) ? balanceWithFeeValue : 0
 
       this.setState({
-        balance: finalBalance,
+        balance: finalBalance.toString(),
       })
       return
     }
@@ -144,15 +146,16 @@ export default class AddOffer extends Component {
     this.checkPair(this.state.sellCurrency)
 
     await this.checkBalance(sellCurrency)
-
     await this.updateExchangeRate(sellCurrency, value)
+
     const { exchangeRate } = this.state
-    sellAmount = new BigNumber(String(buyAmount) || 0).multipliedBy(exchangeRate)
+
+    sellAmount = new BigNumber(buyAmount || 0).multipliedBy(exchangeRate)
 
     const isBuyFieldInteger = config.erc20[buyCurrency] && config.erc20[buyCurrency].decimals === 0
 
     if (isBuyFieldInteger) {
-      buyAmount = new BigNumber(String(buyAmount) || 0).dp(0, BigNumber.ROUND_HALF_EVEN)
+      buyAmount = new BigNumber(buyAmount || 0).dp(0, BigNumber.ROUND_HALF_EVEN)
     }
     this.setState({
       buyCurrency: value,
@@ -173,15 +176,16 @@ export default class AddOffer extends Component {
     this.checkPair(value)
 
     await this.checkBalance(value)
-
     await this.updateExchangeRate(value, buyCurrency)
+
     const { exchangeRate } = this.state
-    buyAmount = new BigNumber(String(sellAmount) || 0).multipliedBy(exchangeRate)
+
+    buyAmount = new BigNumber(sellAmount || 0).multipliedBy(exchangeRate)
 
     const isSellFieldInteger = config.erc20[sellCurrency] && config.erc20[sellCurrency].decimals === 0
 
     if (isSellFieldInteger) {
-      sellAmount = new BigNumber(String(sellAmount) || 0).dp(0, BigNumber.ROUND_HALF_EVEN)
+      sellAmount = new BigNumber(sellAmount || 0).dp(0, BigNumber.ROUND_HALF_EVEN)
     }
 
     this.setState({
@@ -238,11 +242,10 @@ export default class AddOffer extends Component {
   }
 
   handleAnyChange = ({ type, value }) => {
-    const { manualRate, exchangeRate, buyAmount, sellAmount } = this.state
+    const { manualRate, exchangeRate, buyAmount, sellAmount, buyCurrency, sellCurrency } = this.state
 
     if (type === 'sell' || type === 'buy') {
       if (!this.isSending) {
-        actions.analytics.dataEvent('orderbook-addoffer-enter-ordervalue')
         this.setState({ isSending: true })
       }
     }
@@ -260,16 +263,22 @@ export default class AddOffer extends Component {
           S++ -> XR -> B++ (Auto Rate)
         */
 
+        const newSellAmount = new BigNumber(value || 0)
+
         if (manualRate) {
-          let newExchangeRate = new BigNumber(String(value)).dividedBy(new BigNumber(String(buyAmount)))
+          const newExchangeRate = new BigNumber(value).dividedBy(buyAmount)
+
           this.setState({
-            exchangeRate: isNumberValid(newExchangeRate) ? newExchangeRate : '',
-            sellAmount: new BigNumber(String(value)),
+            exchangeRate: newExchangeRate.isGreaterThan(0) ? newExchangeRate.toString() : '',
+            sellAmount: newSellAmount.toString(),
           })
         } else {
+          const newBuyAmount = newSellAmount.multipliedBy(exchangeRate || 0)
+            .dp(constants.tokenDecimals[buyCurrency.toUpperCase()], BigNumber.ROUND_DOWN)
+
           this.setState({
-            sellAmount: new BigNumber(String(value)),
-            buyAmount: new BigNumber(String(value) || 0).multipliedBy(exchangeRate || 0),
+            sellAmount: newSellAmount.toString(),
+            buyAmount: newBuyAmount.toString(),
           })
         }
         break
@@ -281,16 +290,22 @@ export default class AddOffer extends Component {
           B++ -> XR -> S++ (Auto Rate)
         */
 
+        const newBuyAmount = new BigNumber(value || 0)
+
         if (manualRate) {
-          let newExchangeRate = new BigNumber(String(sellAmount)).dividedBy(new BigNumber(String(value)))
+          const newExchangeRate = new BigNumber(sellAmount).dividedBy(value)
+
           this.setState({
-            exchangeRate: isNumberValid(newExchangeRate) ? newExchangeRate : '',
-            buyAmount: new BigNumber(String(value)),
+            exchangeRate: newExchangeRate.isGreaterThan(0) ? newExchangeRate.toString() : '',
+            buyAmount: newBuyAmount.toString(),
           })
         } else {
+          const newSellAmount = newBuyAmount.dividedBy(exchangeRate || 0)
+            .dp(constants.tokenDecimals[sellCurrency.toUpperCase()], BigNumber.ROUND_DOWN)
+
           this.setState({
-            sellAmount: new BigNumber(String(value) || 0).dividedBy(exchangeRate || 0),
-            buyAmount: new BigNumber(String(value)),
+            sellAmount: newSellAmount.toString(),
+            buyAmount: newBuyAmount.toString(),
           })
         }
 
@@ -304,14 +319,10 @@ export default class AddOffer extends Component {
             XR++ -> S -> B--
           */
 
-          let newBuyAmount  = new BigNumber(String(sellAmount)).dividedBy(value)
-
-          if (!isNumberValid(newBuyAmount)) {
-            newBuyAmount = new BigNumber('0')
-          }
+          const newBuyAmount  = new BigNumber(sellAmount).dividedBy(value || 0)
 
           this.setState({
-            buyAmount: newBuyAmount,
+            buyAmount: newBuyAmount.toString(),
           })
         } else {
           // Otherwise change sell value if buy value is not null
@@ -319,14 +330,10 @@ export default class AddOffer extends Component {
             XR++ -> S++ -> B
           */
 
-          let newSellAmount = new BigNumber(String(value)).multipliedBy(buyAmount)
-
-          if (!isNumberValid(newSellAmount)) {
-            newSellAmount = new BigNumber('0')
-          }
+          const newSellAmount = new BigNumber(value || 0).multipliedBy(buyAmount)
 
           this.setState({
-            sellAmount: newSellAmount,
+            sellAmount: newSellAmount.toString(),
           })
         }
 
@@ -339,10 +346,14 @@ export default class AddOffer extends Component {
   }
 
   handleNext = () => {
-    const { exchangeRate, buyAmount, sellAmount, balance, sellCurrency, ethBalance, isToken } = this.state
+    const { exchangeRate, buyAmount, sellAmount, balance, sellCurrency, isToken } = this.state
     const { onNext, tokenItems } = this.props
 
-    const isDisabled = !exchangeRate || !buyAmount || !sellAmount || sellAmount > balance || !isToken && sellAmount < minAmount[sellCurrency]
+    const isDisabled = !exchangeRate
+      || !buyAmount
+      || !sellAmount
+      || new BigNumber(sellAmount).isGreaterThan(balance)
+      || !isToken && new BigNumber(sellAmount).isLessThan(minAmount[sellCurrency])
 
 
     if (!isDisabled) {
@@ -352,17 +363,18 @@ export default class AddOffer extends Component {
   }
 
   changeBalance = (value) => {
-    this.setState({
+    this.setState(() => ({
       sellAmount: value,
-    })
+    }))
     this.handleSellAmountChange(value)
   }
 
   handleManualRate = (value) => {
     if (!value) {
-      this.handleSellCurrencySelect({ value:this.state.sellCurrency })
+      const { sellCurrency } = this.state
+      this.handleSellCurrencySelect({ value: sellCurrency })
     }
-    this.setState({ manualRate: value })
+    this.setState(() => ({ manualRate: value }))
   }
 
   switching = async (value) => {
@@ -371,20 +383,21 @@ export default class AddOffer extends Component {
     await this.checkBalance(buyCurrency)
     await this.updateExchangeRate(buyCurrency, sellCurrency)
 
-    if (Number(sellAmount) > 0 || Number(buyAmount) > 0) {
+    actions.pairs.selectPair(buyCurrency)
+
+    this.setState(() => ({
+      sellCurrency: buyCurrency,
+      buyCurrency: sellCurrency,
+    }))
+
+    if (sellAmount > 0 || buyAmount > 0) {
       this.handleBuyAmountChange(sellAmount)
       this.handleSellAmountChange(buyAmount)
     }
-    actions.pairs.selectPair(buyCurrency)
-    this.setState({
-      sellCurrency: buyCurrency,
-      buyCurrency: sellCurrency,
-    })
   }
 
   checkPair = (value) => {
     const selected = actions.pairs.selectPair(value)
-
     const check = selected.map(item => item.value).includes(this.state.buyCurrency)
 
     if (!check) {
@@ -395,23 +408,26 @@ export default class AddOffer extends Component {
   }
 
   render() {
-
     const { currencies, tokenItems, addSelectedItems } = this.props
     const { exchangeRate, buyAmount, sellAmount, buyCurrency, sellCurrency,
-      balance, isBuyFieldInteger, isSellFieldInteger, ethBalance, manualRate, isPartial, isToken } = this.state
+      balance, isBuyFieldInteger, isSellFieldInteger, manualRate, isPartial, isToken } = this.state
     const linked = Link.all(this, 'exchangeRate', 'buyAmount', 'sellAmount')
-    const minimalAmount = !isToken ? Math.floor(minAmount[sellCurrency] * 1e6) / 1e6 : 0
+    const minimalAmount = !isToken
+      ? new BigNumber(minAmount[sellCurrency]).dp(6, BigNumber.ROUND_DOWN).toString()
+      : 0
 
-    const isDisabled = !exchangeRate || !buyAmount && !sellAmount
-      || sellAmount > balance || !isToken && sellAmount < minimalAmount
+    const isDisabled = !exchangeRate
+      || !buyAmount && !sellAmount
+      || new BigNumber(balance).isLessThanOrEqualTo(sellAmount)
+      || !isToken && new BigNumber(minimalAmount).isGreaterThanOrEqualTo(sellAmount)
 
-    linked.sellAmount.check((value) => (Number(value) > minimalAmount),
+    linked.sellAmount.check((value) => new BigNumber(minimalAmount).isLessThanOrEqualTo(value),
       <span style={{ position: 'relative', marginRight: '44px' }}>
         <FormattedMessage id="transaction368" defaultMessage="Amount must be greater than " />
         {minimalAmount}
       </span>
     )
-    linked.sellAmount.check((value) => Number(value) <= balance,
+    linked.sellAmount.check((value) => new BigNumber(balance).isGreaterThan(value),
       <span style={{ position: 'relative', marginRight: '44px' }}>
         <FormattedMessage id="transaction376" defaultMessage="Amount must be less than your balance " />
       </span>


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description

<!-- Include issue number and motivation for these code changes -->


Fix issue #1524 

### Video or screenshot

<!-- Paste video or screenshots -->

eth has 18 max length (it had 20):

![screenshot_20190209_231945](https://user-images.githubusercontent.com/43396375/52521559-9cf49e80-2cc4-11e9-8c10-c056087da1e0.png)



### What and how to test

<!-- What reviewer should do? -->


Create some offer with eth


