### PR TITLE
показ списка незаконченных свапов, только если залочены средства(шаг 4)

### DIFF
--- a/shared/components/KeyActionsPanel/KeyActionsPanel.js
+++ b/shared/components/KeyActionsPanel/KeyActionsPanel.js
@@ -63,9 +63,8 @@ export default class KeyActionsPanel extends Component {
 
       decline.forEach(item => {
         const order = actions.core.getSwapById(item)
-        const step = order.flow.state.step
 
-        if (!order.flow.state.isSwapExist && !order.isMy && step >= 4) {
+        if (!order.flow.state.isSwapExist && !order.isMy && order.flow.state.step >= 4) {
           desclineOrders.push(order)
         }
       })

--- a/shared/components/KeyActionsPanel/KeyActionsPanel.js
+++ b/shared/components/KeyActionsPanel/KeyActionsPanel.js
@@ -63,7 +63,9 @@ export default class KeyActionsPanel extends Component {
 
       decline.forEach(item => {
         const order = actions.core.getSwapById(item)
-        if (!order.flow.state.isSwapExist && !order.isMy) {
+        const step = order.flow.state.step
+
+        if (!order.flow.state.isSwapExist && !order.isMy && step >= 4) {
           desclineOrders.push(order)
         }
       })

--- a/shared/components/modals/IncompletedSwaps/IncompletedSwaps.js
+++ b/shared/components/modals/IncompletedSwaps/IncompletedSwaps.js
@@ -39,7 +39,7 @@ export default class IncompletedSwaps extends Component {
         <div styleName="modal">
           <div styleName="modal_column">
             <SubTitle styleName="modal_column-title">
-              <FormattedMessage id="IncompletedSwaps49" defaultMessage="Swaps needing to complete" />
+              <FormattedMessage id="IncompletedSwaps49" defaultMessage="Swaps that needs to complete" />
             </SubTitle>
             { swapHistory.length > 0 ?
               <SwapsHistory
@@ -48,6 +48,7 @@ export default class IncompletedSwaps extends Component {
                   .filter(item => item.isSwapExist === false)
                   .filter(item => item.isMy === false)
                   .filter(item => decline.includes(item.id))
+                  .filter(item => item.step >= 4)
                 }
               /> :
               <h1>

--- a/shared/helpers/handleGoTrade.js
+++ b/shared/helpers/handleGoTrade.js
@@ -11,8 +11,11 @@ const getDeclinedExistedSwapIndex = ({ currency, decline }) => {
   const declineSwap = actions.core.getSwapById(decline[indexOfDecline])
 
   const itemState = declineSwap.flow.state
-
   const values = itemState.btcScriptValues || itemState.ltcScriptValues || itemState.usdtScriptValues || itemState.scriptValues
+
+  if (values === undefined) {
+    return false
+  }
 
   const lockTime = moment.unix(values.lockTime || date)._i / 1000
   const timeSinceLock = date - lockTime

--- a/shared/pages/Swap/Swap.js
+++ b/shared/pages/Swap/Swap.js
@@ -132,18 +132,21 @@ export default class SwapComponent extends PureComponent {
 
     if (!this.props.decline.includes(orderId)) {
       this.setSaveSwapId(orderId)
-      this.saveThisSwap(orderId)
     }
   }
 
   componentDidMount() {
-    const { swap: { id, flow: { state: { canCreateEthTransaction, requireWithdrawFeeSended } } }, continueSwap, deletedOrders } = this.state
-
+    const { swap: { id, flow: { state: { canCreateEthTransaction, requireWithdrawFeeSended, step } } }, continueSwap, deletedOrders } = this.state
+    let { match : { params : { orderId } } } = this.props
     if (localStorage.getItem('deletedOrders') !== null) {
 
       if (localStorage.getItem('deletedOrders').includes(id)) {
         this.props.history.push(localisedUrl(links.exchange))
       }
+    }
+
+    if (step >= 4 && !this.props.decline.includes(orderId)) {
+      console.log('sdl;mfjsidkbnfisdljmocksdnvijksldknzmcilksnmadjivkcnfsjkcnsdjkv,ncm')
     }
 
     if (this.state.swap !== null) {

--- a/shared/pages/Swap/Swap.js
+++ b/shared/pages/Swap/Swap.js
@@ -146,7 +146,7 @@ export default class SwapComponent extends PureComponent {
     }
 
     if (step >= 4 && !this.props.decline.includes(orderId)) {
-      console.log('sdl;mfjsidkbnfisdljmocksdnvijksldknzmcilksnmadjivkcnfsjkcnsdjkv,ncm')
+      this.saveThisSwap(orderId)
     }
 
     if (this.state.swap !== null) {


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [ ] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description

<!-- Include issue number and motivation for these code changes -->




### Video or screenshot

<!-- Paste video or screenshots -->




### What and how to test

<!-- What reviewer should do? -->




#  Для маркет тейкера
Начинаем свап, покидаем до 4 шага и все хорошо, можно начать новый свап и не появляется подобная кнопка
![image](https://user-images.githubusercontent.com/43392281/54618359-a258bc00-4aae-11e9-8f9a-3007592bb90f.png)

начинаем свап и наоборот покидаем на 4 или после, после выхода, появляются 
- кнопка(скрин выше)
- нельзя начать новый обмен
