### PR TITLE
Кеширование данных о коммисии + Опция для включения кеширования у request.get/post/etc

### DIFF
--- a/shared/helpers/btc.js
+++ b/shared/helpers/btc.js
@@ -63,7 +63,7 @@ const estimateFeeRate = async ({ speed = 'fast' } = {}) => {
   let apiResult
 
   try {
-    apiResult = await request.get(link)
+    apiResult = await request.get(link, { cacheResponse: 60000 })
   } catch (err) {
     console.error(`EstimateFeeRate: ${err.message}`)
     return defaultRate[speed]

--- a/shared/helpers/eth.js
+++ b/shared/helpers/eth.js
@@ -25,7 +25,7 @@ const estimateGasPrice = async ({ speed = 'fast' } = {}) => {
   let apiResult
 
   try {
-    apiResult = await request.get(link)
+    apiResult = await request.get(link, { cacheResponse: 60000 })
   } catch (err) {
     console.error(`EstimateGasPrice: ${err.message}`)
     return defaultPrice[speed]

--- a/shared/helpers/ltc.js
+++ b/shared/helpers/ltc.js
@@ -64,7 +64,7 @@ const estimateFeeRate = async ({ speed = 'fast' } = {}) => {
   let apiResult
 
   try {
-    apiResult = await request.get(link)
+    apiResult = await request.get(link, { cacheResponse: 60000 })
   } catch (err) {
     console.error(`EstimateFeeRate: ${err.message}`)
     return defaultRate[speed]

--- a/shared/helpers/request.js
+++ b/shared/helpers/request.js
@@ -1,9 +1,48 @@
 import request from 'superagent'
 
+const responseCacheStorage = {}
+
+const responseCacheGetKey = (req, opts) => `${opts.method}-${opts.endpoint}`
+
+const responseCacheGet = (req, opts) => {
+  const cacheKey =  responseCacheGetKey(req, opts)
+
+  if (opts
+    && opts.cacheResponse
+    && responseCacheStorage[cacheKey]
+    && ((responseCacheStorage[cacheKey].cacheResponseCreateTime + responseCacheStorage[cacheKey].cacheResponse) >= new Date().getTime())
+  ) {
+    return responseCacheStorage[cacheKey]
+  } return false
+}
+
+const responseCacheAdd = (req, opts, resData, res) => {
+  const cacheKey = responseCacheGetKey(req, opts)
+  const cacheResponse = { opts }
+  const cacheResponseCreateTime = new Date().getTime()
+
+  responseCacheStorage[cacheKey] = {
+    cacheResponse,
+    cacheResponseCreateTime,
+    resData,
+    res,
+  }
+}
 
 const createResponseHandler = (req, opts) => {
   const debug = `${opts.method.toUpperCase()} ${opts.endpoint}`
 
+  // cached answer
+  const cachedAnswer = responseCacheGet(req, opts)
+
+  if (cachedAnswer) {
+    return new Promise((fulfill, reject) => {
+      fulfill(cachedAnswer.resData, cachedAnswer.res)
+      opts.onComplete()
+    })
+  }
+
+  // no cache - do request
   return new Promise((fulfill, reject) => req.end((err, res) => {
     let serverError
 
@@ -39,6 +78,11 @@ const createResponseHandler = (req, opts) => {
     }
 
     const resData = opts.modifyResult(body)
+
+    // Cache result if needs
+    if (opts.cacheResponse) {
+      responseCacheAdd(req, opts, resData, res)
+    }
 
     // Resolve
 

--- a/shared/redux/actions/btc.js
+++ b/shared/redux/actions/btc.js
@@ -186,7 +186,7 @@ const signAndBuildKeychain = async (transactionBuilder, unspents) => {
 }
 
 const fetchUnspents = (address) =>
-  request.get(`${api.getApiServer('bitpay')}/addr/${address}/utxo`)
+  request.get(`${api.getApiServer('bitpay')}/addr/${address}/utxo`, { cacheResponse: 5000 })
 
 const broadcastTx = (txRaw) =>
   request.post(`${api.getApiServer('bitpay')}/tx/send`, {


### PR DESCRIPTION


- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Из-за частого обращения к API, для получения информации, о размере комиссии для разных скоростей майнинга транзакции, сервис дает бан (Too many request)

Добавил опцию к методам request.get/post/etc ( cacheResponse - время кеширования ответа в миллисекундах)

Выставил кеш для размеров комиссии - 1 минута

### Video or screenshot
#### Было
"Спам запросов"
![image](https://user-images.githubusercontent.com/1880211/55439806-60e80680-55ae-11e9-8b94-19d96334b2e8.png)
Вероятность того, что за две-пять-десять секунд, размер комиссии (майнер-фии) измениться - ничтожно мала
Как-результат 
![image](https://user-images.githubusercontent.com/1880211/55439874-95f45900-55ae-11e9-9230-1c1c859ff97e.png)
Ошибка "Too many request"


### What and how to test





