### PR TITLE
downgrade mortice module - for upgrade needed typescript + babel7

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,7 @@
     "replace": "^1.0.0",
     "reverse": "^4.0.0",
     "stellar-sdk": "^0.11.0",
-    "styled-components": "^4.1.2"
+    "styled-components": "^4.1.2",
+    "mortice": "1.2.1"
   }
 }


### PR DESCRIPTION
Не собирался билд на unix-системах

Понизил версию mortice с 1.2.2 до 1.2.1
Версия 1.2.2 тянет зависимость p-query версии ^5.0.0, в которой используется TypeScript
Для TypeScript нужен babel 7й версии и обновление конфигов web-pack (отдельное ишью)
