### PR TITLE
SwapProgress: remove btc withdraw transaction link for btc2eth swap

### DIFF
--- a/shared/pages/Swap/SwapProgress/SwapProgress.js
+++ b/shared/pages/Swap/SwapProgress/SwapProgress.js
@@ -361,7 +361,7 @@ export default class SwapProgress extends Component {
                 </a>
               </strong>
             )}
-            {flow.btcSwapWithdrawTransactionHash && (
+            {flow.btcSwapWithdrawTransactionHash && swap.buyCurrency === 'BTC' && (
               <strong styleName="transaction">
                 <a
                   href={`${config.link.bitpay}/tx/${flow.btcSwapWithdrawTransactionHash}`}


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [x] testing instruction attached
- [x] check your PR once again


### Description

<!-- Include issue number and motivation for these code changes -->

Issue #1964 


### Video or screenshot

<!-- Paste video or screenshots -->


![Screenshot_20190610_000112](https://user-images.githubusercontent.com/43396375/59159897-606e6d80-8b13-11e9-883c-aa9b5464b9c7.png)


### What and how to test

<!-- What reviewer should do? -->





