### PR TITLE
Issue 1984 - no orders found + max sell amount informer

### DIFF
--- a/shared/pages/PartialClosure/PartialClosure.js
+++ b/shared/pages/PartialClosure/PartialClosure.js
@@ -362,14 +362,14 @@ export default class PartialClosure extends Component {
   }
 
   sendRequest = () => {
-    const { getAmount, haveAmount, peer, orderId, customWallet } = this.state
+    const { getAmount, haveAmount, peer, orderId, customWallet, maxAmount, maxBuyAmount } = this.state
 
     if (!String(getAmount) || !peer || !orderId || !String(haveAmount)) {
       return
     }
 
     const newValues = {
-      sellAmount: getAmount,
+      sellAmount: (maxBuyAmount.isEqualTo(haveAmount)) ? maxAmount : getAmount,
     }
 
     const destination = {
@@ -454,7 +454,7 @@ export default class PartialClosure extends Component {
   }
 
   setAmountOnState = (maxAmount, getAmount, buyAmount) => {
-    const { getCurrency } = this.state
+    const { getCurrency, haveAmount } = this.state
     const decimalPlaces = constants.tokenDecimals[getCurrency.toLowerCase()]
 
     this.setState(() => ({
@@ -463,7 +463,7 @@ export default class PartialClosure extends Component {
       maxBuyAmount: buyAmount,
     }))
 
-    return BigNumber(getAmount).isLessThanOrEqualTo(maxAmount)
+    return BigNumber(getAmount).isLessThanOrEqualTo(maxAmount) || BigNumber(haveAmount).isEqualTo(buyAmount)
   }
 
   setAmount = (value) => {
@@ -474,7 +474,12 @@ export default class PartialClosure extends Component {
     const { filteredOrders, haveAmount, exHaveRate, exGetRate } = this.state
 
     if (filteredOrders.length === 0) {
-      this.setNoOfferState()
+      this.setState(() => ({
+        isNonOffers: true,
+        maxAmount: 0,
+        getAmount: 0,
+        maxBuyAmount: BigNumber(0),
+      }))
       return
     }
 
@@ -560,6 +565,7 @@ export default class PartialClosure extends Component {
     if (!checkAmount) {
       this.setNoOfferState()
     }
+
     return true
   }
 
@@ -956,8 +962,12 @@ export default class PartialClosure extends Component {
                 <FormattedMessage id="PartialPriceNoOrdersReduce" defaultMessage="No orders found, try to reduce the amount" />
               </p>
               <p styleName="error" className={isWidget ? 'error' : ''} >
-                <FormattedMessage id="PartialPriceReduceMin" defaultMessage="Maximum available amount: " />
+                <FormattedMessage id="PartialPriceReduceMin" defaultMessage="Maximum available amount for buy: " />
                 {maxAmount}{' '}{getCurrency.toUpperCase()}
+              </p>
+              <p styleName="error" className={isWidget ? 'error' : ''} >
+                <FormattedMessage id="PartialPriceSellMax" defaultMessage="Maximum available amount for sell: " />
+                {maxBuyAmount.toNumber()}{' '}{haveCurrency.toUpperCase()}
               </p>
             </Fragment>
           )}


### PR DESCRIPTION
# Pull request template

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description
Решение ишью https://github.com/swaponline/swap.react/issues/1984
При перезагрузке бота, когда в ордербуке не оставалось ордеров, выставляло флаг "нет ордеров", при этом не обнуляло значения максимальных доступных объемов - из-за этого появлялось сообщение. 
Теперь при перезагрузке бота (обнулении ордербука) - появляется информер "поиск предложений" и обнуляет поле "you get"
Сразу, после появления предложений в ордербуке - происходит расчет и пользователю становиться доступен обмен

Так же добавил информирование о максимальной сумме, которую можно продать 
Было не совсем понятно, выводилось, сколько пользователь может получить, но при этом не понятно, сколько он может максимум продать, и приходилось подбирать значение вручную


Так же исправил баг, что нельзя было выкупить все доступное предложение - запрос уходил в вечное ожидание. Теперь, если на рынке доступно для покупки 0.05 btc -  то пользователь может продать эту сумму



### Video or screenshot
Пользователю расчиталло предложение
![image](https://user-images.githubusercontent.com/1880211/59936693-545ea600-9459-11e9-97c3-bfc16577a987.png)
Бот ушел в рестарт (обнулен ордербук)
![image](https://user-images.githubusercontent.com/1880211/59936898-ca630d00-9459-11e9-9899-24d75ef984bf.png)


Информирование пользователя о максимальных суммах, доступных для операций
![image](https://user-images.githubusercontent.com/1880211/59936516-e2865c80-9458-11e9-8619-640105e1f81a.png)



### What and how to test

<!-- What reviewer should do? -->





