### PR TITLE
Issue2009 - Валидация альтернативного адреса при подтверждении запроса

### DIFF
--- a/shared/components/modals/ConfirmBeginSwap/ConfirmBeginSwap.js
+++ b/shared/components/modals/ConfirmBeginSwap/ConfirmBeginSwap.js
@@ -196,7 +196,7 @@ export default class ConfirmBeginSwap extends React.Component {
                   {
                     (!this.customWalletIsValid()) && (
                       <div styleName="error">
-                        You specify not valid wallet address
+                        <FormattedMessage id="CustomWalletIsNotCorrect" defaultMessage="Wallet address is incorrect" />
                       </div>
                     )
                   }

--- a/shared/components/modals/ConfirmBeginSwap/ConfirmBeginSwap.scss
+++ b/shared/components/modals/ConfirmBeginSwap/ConfirmBeginSwap.scss
@@ -23,6 +23,18 @@
   }
 }
 
+.error {
+  display: flex;
+  align-items: center;
+  color: #fff;
+  padding: 0.3em 10px;
+  margin-top: -5px;
+  font-size: 13px;
+  background: #FD6B65;
+  border-radius: 3px;
+  margin-bottom: 15px;
+}
+
 .closeButton {
   width: 20px;
   height: 20px;


### PR DESCRIPTION
# Pull request template

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Решение ишью https://github.com/swaponline/swap.react/issues/2009

Исправил неправильный адрес кошелька
Добавил валидацию адреса

Альтернативный адрес доступен для BTC-ETH, ETH-BTC, Token-BTC, BTC-Token




### Video or screenshot

<!-- Paste video or screenshots -->
![image](https://user-images.githubusercontent.com/1880211/60253142-459e4600-98d4-11e9-9f77-ad4c46b6d415.png)





### What and how to test

<!-- What reviewer should do? -->





