### PR TITLE
Не давать два раза активировать бтц-смс

### DIFF
--- a/shared/components/modals/RegisterSMSProtected/RegisterSMSProtected.js
+++ b/shared/components/modals/RegisterSMSProtected/RegisterSMSProtected.js
@@ -72,11 +72,9 @@ export default class RegisterSMSProtected extends React.Component {
     const result = await actions.btcmultisig.confirmRegister( this.state.phone, this.state.smsCode )
     
     if (result && result.answer && result.answer=='ok') {
-      localStorage.setItem(constants.localStorage.didProtectedBtcCreated, "1")
       this.setState( { isShipped: false, step: 'ready' } )
     } else {
       if (result.error == 'Already registered') {
-        localStorage.setItem(constants.localStorage.didProtectedBtcCreated, "1")
         this.setState( { isShipped: false, step: 'ready' } )
       } else {
         this.setState( { isShipped: false, error: (result.error) ? result.error : 'Unknown error' } )

--- a/shared/pages/CreateWallet/CreateWallet.scss
+++ b/shared/pages/CreateWallet/CreateWallet.scss
@@ -166,6 +166,16 @@
   opacity: 0.7 !important;
 }
 
+.cardActivated {
+  border: 1px solid rgba(102, 204, 87, 0.64) !important;
+  div, img {
+    opacity: 0.5 !important;
+  }
+  em {
+    color: #48ca2f !important;
+  }
+}
+
 .secondStepInput {
   height: 50px;
   border: 1px solid rgba(0, 0, 0, 0.1);

--- a/shared/pages/CreateWallet/Steps/SecondStep.js
+++ b/shared/pages/CreateWallet/Steps/SecondStep.js
@@ -12,6 +12,7 @@ import { isMobile } from 'react-device-detect'
 
 import config from 'app-config'
 import { constants } from 'helpers'
+import actions from 'redux/actions'
 
 import Explanation from '../Explanation'
 import icons from '../images'
@@ -43,9 +44,10 @@ const CreateWallet = (props) => {
     multisign: {},
   }
 
-  if (currencies.btc) _protection.sms.btc = true
-
-  if (localStorage.getItem(constants.localStorage.didProtectedBtcCreated) === '1') _activated.sms.btc = true
+  if (currencies.btc) {
+    _protection.sms.btc = true
+    _activated.sms.btc = actions.btcmultisig.checkSMSActivated()
+  }
 
   const [border, setBorder] = useState({
     color: {

--- a/shared/pages/CreateWallet/Steps/SecondStep.js
+++ b/shared/pages/CreateWallet/Steps/SecondStep.js
@@ -10,6 +10,9 @@ import ReactTooltip from 'react-tooltip'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import { isMobile } from 'react-device-detect'
 
+import config from 'app-config'
+import { constants } from 'helpers'
+
 import Explanation from '../Explanation'
 import icons from '../images'
 import { subHeaderText1,
@@ -22,9 +25,27 @@ import { subHeaderText1,
 const CreateWallet = (props) => {
   const { intl: { locale }, onClick, currencies, error, setError } = props
 
-  let smsProtectionEnabled = false
+  const _protection = {
+    nothing: {
+      btc: true,
+      eth: true,
+      erc: true,
+    },
+    sms: {},
+    g2fa: {},
+    multisign: {},
+  }
 
-  if (currencies.btc) smsProtectionEnabled = true
+  const _activated = {
+    nothing: {},
+    sms: {},
+    g2fa: {},
+    multisign: {},
+  }
+
+  if (currencies.btc) _protection.sms.btc = true
+
+  if (localStorage.getItem(constants.localStorage.didProtectedBtcCreated) === '1') _activated.sms.btc = true
 
   const [border, setBorder] = useState({
     color: {
@@ -36,8 +57,10 @@ const CreateWallet = (props) => {
     selected: '',
   })
 
-  const handleClick = (name, index, enabled) => {
+  const handleClick = (index, el) => {
+    const { name, enabled, activated } = el
     if (!enabled) return
+    if (activated) return
     const colors = border.color
 
     Object.keys(border.color).forEach(el => {
@@ -58,12 +81,14 @@ const CreateWallet = (props) => {
       name: 'withoutSecure',
       capture: locale === 'en' ? 'suitable for small amounts' : 'Подходит для небольших сумм',
       enabled: true,
+      activated: false,
     },
     { 
       text: 'SMS',
       name: 'sms',
       capture: locale === 'en' ? 'transactions are confirmed by SMS code' : 'Транзакции подтверждаются кодом по SMS',
-      enabled: smsProtectionEnabled,
+      enabled: _protection.sms.btc /* || _protection.sms.eth || _protection.sms.erc */,
+      activated: _activated.sms.btc /* || _activated.sms.eth || _activated.sms.erc */,
     },
     {
       text: 'Google 2FA',
@@ -72,6 +97,7 @@ const CreateWallet = (props) => {
         'Transactions are verified through the Google Authenticator app' :
         'Транзакции подтверждаются через приложение Google Authenticator',
       enabled: false,
+      activated: false,
     },
     {
       text: 'Multisignature',
@@ -80,6 +106,7 @@ const CreateWallet = (props) => {
         'Transactions are confirmed from another device and / or by another person.' :
         'Транзакции подтверждаются с другого устройства и/или другим человеком',
       enabled: false,
+      activated: false,
     },
   ]
 
@@ -99,17 +126,25 @@ const CreateWallet = (props) => {
           </Explanation>
           <div styleName="currencyChooserWrapper currencyChooserWrapperSecond">
             {coins.map((el, index) => {
-              const { name, capture, text, enabled } = el
+              const { name, capture, text, enabled, activated } = el
+
+              const cardStyle = [ 'card', 'secureSize', 'thirdCard' ]
+
+              if (border.color[name] && enabled) cardStyle.push('purpleBorder')
+              if (!enabled) cardStyle.push('cardDisabled')
+
+              if (activated) cardStyle.push('cardActivated')
+              const cardStyle_ = cardStyle.join(' ')
+
               return (
                 <div
-                  styleName={
-                    `card secureSize thirdCard ${border.color[name] && enabled ? 'purpleBorder' : ''} ${!enabled ? 'cardDisabled' : ''}`
-                  }
-                  onClick={() => handleClick(name, index, enabled)}
+                  styleName={`${cardStyle_}`}
+                  onClick={() => handleClick(index, el)}
                 >
-                  {!enabled &&
+                  {(!enabled || activated) &&
                     <em>
-                      <FormattedMessage id="createWalletSoon" defaultMessage="Soon!" />
+                      {!activated && <FormattedMessage id="createWalletSoon" defaultMessage="Soon!" /> }
+                      {activated && <FormattedMessage id="createWalletActivated" defaultMessage="Activated!" /> }
                     </em>
                   }
                   <img

--- a/shared/redux/actions/btcmultisig.js
+++ b/shared/redux/actions/btcmultisig.js
@@ -18,6 +18,10 @@ const addWallet = (otherOwnerPublicKey) => {
 }
 window.MS_addWallet = addWallet
 
+const checkSMSActivated = () => {
+  const { user: { btcMultisigData : { isRegistered } } } = getState()
+  return isRegistered
+}
 
 const createWallet = (privateKey, otherOwnerPublicKey) => {
   // privateKey - key of our privary one-sign btc wallet
@@ -117,7 +121,8 @@ const login = (privateKey, otherOwnerPublicKey) => {
     const { address } = p2sh
     
     const { addressOfMyOwnWallet }   = bitcoin.payments.p2wpkh({ pubkey: account.publicKey, network: btc.network })
-    const isRegistered = (localStorage.getItem(constants.localStorage.didProtectedBtcCreated) == "1") ? true : false
+
+    const isRegistered = (localStorage.getItem(`${constants.localStorage.didProtectedBtcCreated}:${address}`) === '1')
 
     _data = {
       account,
@@ -201,6 +206,11 @@ const confirmRegister = async (phone, smsCode) => {
       mainnet: process.env.MAINNET ? true : false,
     },
   })
+
+  if ((result && result.answer && result.answer === 'ok') || (result.error === 'Already registered')) {
+    localStorage.setItem(`${constants.localStorage.didProtectedBtcCreated}:${address}`, '1')
+  }
+
   return result
 }
 
@@ -519,6 +529,7 @@ const getReputation = () =>
 export default {
   beginRegister,
   confirmRegister,
+  checkSMSActivated,
   login,
   loginWithKeychain,
   getBalance,


### PR DESCRIPTION
# Pull request template

## Checklist

<!-- You have to tick all the boxes -->

- [x] I have read the [CONTRIBUTING](https://github.com/swaponline/swap.react/wiki/CONTRIBUTING) guide
- [x] branch rebased on `develop`
- [x] styleguide check `npm run validate`
- [x] good naming
- [x] keep simple
- [x] video or screenshot attached
- [ ] testing instruction attached
- [x] check your PR once again


### Description

Не дает второй раз активировать бтц-смс. Учитывает приватник (адресс) кошелька - то-есть - при импорте приватника (основного бтц), если для него уже была активирована смс-защита в этом браузере - повторная активация с подтверждением по смс не нужна





### Video or screenshot

<!-- Paste video or screenshots -->
![image](https://user-images.githubusercontent.com/1880211/68798226-11e77100-0667-11ea-93e4-2dd57bb35c79.png)





### What and how to test

<!-- What reviewer should do? -->





